### PR TITLE
404 Page

### DIFF
--- a/assets/scss/footnotes.scss
+++ b/assets/scss/footnotes.scss
@@ -23,6 +23,10 @@
 
 .littlefoot-footnote__content {
   max-height: 500px !important;
+
+  p {
+    min-width: 450px;
+  }
 }
 
 /*

--- a/assets/scss/mobile.scss
+++ b/assets/scss/mobile.scss
@@ -92,6 +92,12 @@
     min-width: 100vw;
   }
 
+  .littlefoot-footnote__content {
+    p {
+      min-width: initial;
+    }
+  }
+
   .guest-essay-container {
     .guest-essay {
       padding: 0;

--- a/assets/scss/unsorted.scss
+++ b/assets/scss/unsorted.scss
@@ -320,3 +320,17 @@ hr {
     }
   }
 }
+
+.error-404 {
+  margin: 100px auto;
+  display: block;
+  text-align: center;
+
+  .text-404 {
+    font-family: sans-serif;
+    font-size: 40px;
+    font-weight: bold;
+    color: $gray-aaa;
+    margin-bottom: 0;
+  }
+}

--- a/content/guest-essays/utilitarianism-and-research-ethics.md
+++ b/content/guest-essays/utilitarianism-and-research-ethics.md
@@ -55,7 +55,7 @@ Modern clinical ethics also emphasizes individual consent and not just the medic
 
 Mill argues that deciding for oneself adds great value to the individual’s life. Individuals tend to know best and care the most about what is good for them, and deciding for ourselves is inherently good for us.[^13] Bioethicists’ defenses of autonomous decision-making, either in the clinic or in research,[^14] essentially repeat Mill’s rationale. If Mill is right then exercising one’s personal autonomy—even against doctors’ advice—will often benefit one overall, even when it harms one's medical interests. Admittedly, individuals do not always benefit overall from having the last say on matters closely affecting their bodies and health—in either clinical care or research. But giving them that veto power even when it fails to maximize well-being may abide by the rules that tend to maximize well-being in the long run[^15]—an old utilitarian recipe for maximizing expected value.[^16]
 
-It may seem as though Kantian ethics can at least require _some_ form of consent to any study participation, whether or not that consent is fully autonomous. But even that is unclear: when Kant mentions the consent requirement, it is a requirement that the individual _could_ possibly consent, not that she _actually_consents.[^17]
+It may seem as though Kantian ethics can at least require _some_ form of consent to any study participation, whether or not that consent is fully autonomous. But even that is unclear: when Kant mentions the consent requirement, it is a requirement that the individual _could_ possibly consent, not that she _actually_ consents.[^17]
 
 ## II. Kantian obstacles to core research ethics norms
 

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+
+<div class="homepage-body">
+
+  <div class="error-404">
+    <p class="text-404">
+      404
+    </p>
+    <p>
+      There is no content at this page address
+    </p>
+    <p>
+      Please use the navigation or search to find what you were looking for
+    </p>
+  </div>
+  
+</div>
+
+{{ end }}


### PR DESCRIPTION
_and_ a bugfix for footnotes that were shorter than 1 line of text:
- previously the triangle-up would point in the wrong location when footnote had little text 😅 