### PR TITLE
Config & formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+pdf
+public
+resources
+static
+themes

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
-{ 
+{
   "endOfLine": "lf",
   "tabWidth": 2,
   "overrides": [

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
+    "DavidAnson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "DavidAnson.vscode-markdownlint"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In the future we may want to use some `rtl` support
 - `site-header.html` is unused - meant for homepage only (would include language dropdown)
 - _favicon_ generated with [this website](https://realfavicongenerator.net/) & added a custom `svg` to handle dark-theme browser, see [instructions](https://web.dev/building-an-adaptive-favicon/)
 - We are using [Prettier](https://prettier.io/) to format our code, along with [prettier-plugin-go-template](https://github.com/NiklasPor/prettier-plugin-go-template). 
-  - Install both globally `npm install -g prettier` & `npm install -g prettier-plugin-go-template` and then run `prettier --write . '!themes/**/*'` to format all the files in the repository.
+  - Install both globally `npm install -g prettier` & `npm install -g prettier-plugin-go-template` and then run `prettier --write .` to format all the files in the repository.
 
 ## Search
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In the future we may want to use some `rtl` support
   - these use the `list.html` _layout_
 - `site-header.html` is unused - meant for homepage only (would include language dropdown)
 - _favicon_ generated with [this website](https://realfavicongenerator.net/) & added a custom `svg` to handle dark-theme browser, see [instructions](https://web.dev/building-an-adaptive-favicon/)
-- We are using [Prettier](https://prettier.io/) to format our code, along with [prettier-plugin-go-template](https://github.com/NiklasPor/prettier-plugin-go-template). 
+- We are using [Prettier](https://prettier.io/) to format our code, along with [prettier-plugin-go-template](https://github.com/NiklasPor/prettier-plugin-go-template).
   - Install both globally `npm install -g prettier` & `npm install -g prettier-plugin-go-template` and then run `prettier --write .` to format all the files in the repository.
 
 ## Search

--- a/content/books/_index.html
+++ b/content/books/_index.html
@@ -58,5 +58,4 @@ title: "Utilitarian Books"
     text="Joshua Greene - Moral Tribes (2013)"
     link="https://www.joshua-greene.net/moral-tribes"
   >}}
-
 </div>

--- a/content/theories-of-wellbeing.md
+++ b/content/theories-of-wellbeing.md
@@ -7,7 +7,7 @@ weight: 4
 image: "/img/Utilitarianism-Website-Logo.png"
 ---
 
-> _“To what shall the character of utility be ascribed, if not to that which is a source of pleasure?”_  <br> \- [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham)[^1]
+> _“To what shall the character of utility be ascribed, if not to that which is a source of pleasure?”_ <br> \- [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham)[^1]
 
 {{< TOC >}}
 

--- a/layouts/_default/book.html
+++ b/layouts/_default/book.html
@@ -17,6 +17,5 @@
     {{ partial "PDF.html" . }}
 
     {{ .Content }}
-
   </div>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
   <div class="homepage-body">
     {{ .Content }}
-
   </div>
 {{ end }}

--- a/layouts/partials/site-navigation-2.html
+++ b/layouts/partials/site-navigation-2.html
@@ -80,7 +80,6 @@
 
         <ul>
           {{ range .Site.Menus.guide }}
-
             <a class="" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
               <li>
                 {{ with .Page }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -10,7 +10,6 @@
 
         <ol>
           {{ range .Site.Menus.main }}
-
             <li
               class="{{ if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }}
                 active
@@ -42,7 +41,6 @@
 
         <ul>
           {{ range .Site.Menus.guest }}
-
             <a class="" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
               <li>
                 <div class="title">

--- a/layouts/shortcodes/book.html
+++ b/layouts/shortcodes/book.html
@@ -1,5 +1,9 @@
 <div class="book">
-    <a href="{{ .Get "link" }}">
-        <img src="{{ .Get "image" }}" alt="{{ .Get "text"}}" title="{{ .Get "text" }}">
-    </a>
+  <a href="{{ .Get "link" }}">
+    <img
+      src="{{ .Get "image" }}"
+      alt="{{ .Get "text" }}"
+      title="{{ .Get "text" }}"
+    />
+  </a>
 </div>

--- a/layouts/shortcodes/essay-author.html
+++ b/layouts/shortcodes/essay-author.html
@@ -1,10 +1,14 @@
 {{ if .Get "noabout" }}
-   
+
 {{ else }}
   <h2>About the Author</h2>
-{{ end }}    
+{{ end }}
 
 
 <div class="thinker essay-author">
-  <img src="{{ .Get "image" }}" alt="{{ .Get "text"}}" title="{{ .Get "text" }}">
+  <img
+    src="{{ .Get "image" }}"
+    alt="{{ .Get "text" }}"
+    title="{{ .Get "text" }}"
+  />
 </div>

--- a/layouts/shortcodes/thinker-image.html
+++ b/layouts/shortcodes/thinker-image.html
@@ -1,5 +1,9 @@
 <div class="thinker">
   {{ with .Page }}
-  <img src="{{ .Params.image }}" alt="{{ .Params.title }}" title="{{ .Params.title }}">
+    <img
+      src="{{ .Params.image }}"
+      alt="{{ .Params.title }}"
+      title="{{ .Params.title }}"
+    />
   {{ end }}
 </div>

--- a/layouts/shortcodes/thinker.html
+++ b/layouts/shortcodes/thinker.html
@@ -1,5 +1,9 @@
 <div class="thinker">
   <a href="{{ .Get "link" }}">
-    <img src="{{ .Get "image" }}" alt="{{ .Get "text"}}" title="{{ .Get "text" }}">
+    <img
+      src="{{ .Get "image" }}"
+      alt="{{ .Get "text" }}"
+      title="{{ .Get "text" }}"
+    />
   </a>
 </div>


### PR DESCRIPTION
Quickfix 😅 

For some reason now `prettier --write .` creates some needless edits to a few markdown files, especially to Peter Singer's book _Animal Liberation_ - adding `\` before the last `_` italic resulting in unitalicized link with a `_` after it :trollface: 

Manually fixed the problem before committing 😅 