### PR TITLE
Glossary

### DIFF
--- a/content/glossary.md
+++ b/content/glossary.md
@@ -1,6 +1,7 @@
 ---
 title: "Glossary"
-date: 2022-08-08T10:10:59-04:00
+date: 2023-01-01T10:10:59-04:00
+updated: 2023, Jan 8th - in sync with website
 draft: false
 weight: 1
 image: "/img/Utilitarianism-Website-Logo.png"

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -11,7 +11,7 @@ This page provides an overview with brief descriptions of key utilitarian terms 
 <details>
 <summary>Act utilitarianism<span class="icon"></span></summary>
 
-Act utilitarianism is the view that one morally ought to promote just the sum total of well-being.1 Act utilitarianism is the best known version of [direct consequentialism](/types-of-utilitarianism#consequentialism) and is often contrasted with _rule utilitarianism_, an indirect consequentialist view. Contemporary utilitarian philosophers often endorse [global utilitarianism](/types-of-utilitarianism#global-utilitarianism), which emphasizes that utilitarian standards of moral evaluation apply to anything of interest (not just acts).2
+Act utilitarianism is the view that one morally ought to promote just the sum total of well-being.[^1] Act utilitarianism is the best known version of [direct consequentialism](/types-of-utilitarianism#consequentialism) and is often contrasted with _rule utilitarianism_, an indirect consequentialist view. Contemporary utilitarian philosophers often endorse [global utilitarianism](/types-of-utilitarianism#global-utilitarianism), which emphasizes that utilitarian standards of moral evaluation apply to anything of interest (not just acts).[^2]
 
 </details>
 
@@ -20,7 +20,7 @@ Act utilitarianism is the view that one morally ought to promote just the sum to
 
 _→ Main article:_ [_Aggregationism_](/types-of-utilitarianism#aggregationism)
 
-Aggregationism holds that the value of the world is the sum of the values of its parts, where these parts are local phenomena such as experiences, lives, or societies.3 When combined with welfarism and the equal consideration of interests, this view implies that we can meaningfully add up the well-being of different individuals, and use this total to determine which trade-offs are worth making. Aggregationism is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
+Aggregationism holds that the value of the world is the sum of the values of its parts, where these parts are local phenomena such as experiences, lives, or societies.[^3] When combined with welfarism and the equal consideration of interests, this view implies that we can meaningfully add up the well-being of different individuals, and use this total to determine which trade-offs are worth making. Aggregationism is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
 
 </details>
 
@@ -49,14 +49,14 @@ _→ Main article:_ [_Arguments for utilitarianism: The Golden Rule, the Veil of
 
 Imagine you had to decide how to structure society from behind a [veil of ignorance](https://plato.stanford.edu/entries/original-position/). Behind this veil of ignorance, you know all the facts about each person’s circumstances in society—what their income is, how happy they are, how they are affected by social policies, and their preferences and likes. However, what you do not know is which of these people you are. You only know that you have an _equal chance_ of being any of these people. Imagine, now, that you are trying to act in a rational and self-interested way—you are just trying to do whatever is best for yourself. How would you structure society?
 
-Nobel Prize-winning economist John Harsanyi proved that in this situation you will structure society to promote the sum total of everyone’s wellbeing.4 In other words, if you are rational and acting in self-interest and were put behind the veil of ignorance, you would come to use some version of utilitarianism as the principle to decide about the structure and rules of society.
+Nobel Prize-winning economist John Harsanyi proved that in this situation you will structure society to promote the sum total of everyone’s wellbeing.[^4] In other words, if you are rational and acting in self-interest and were put behind the veil of ignorance, you would come to use some version of utilitarianism as the principle to decide about the structure and rules of society.
 
 </details>
 
 <details>
 <summary>Astronomical waste<span class="icon"></span></summary>
 
-Oxford philosopher Nick Bostrom [writes that](https://www.nickbostrom.com/astronomical/waste.pdf) “With very advanced technology, a very large population of people living happy lives could be sustained in the accessible region of the universe. For every year that development of such technologies and colonization of the universe is delayed, there is therefore a corresponding opportunity cost: a potential good, lives worth living, is not being realized”.5 He coined the term “astronomical waste” to describe this opportunity cost of delayed technological development. Bostrom argues that, despite this large opportunity cost, utilitarians should not aim to maximize the rate of technological progress “but rather that we ought to maximize its safety, i.e. the probability that colonization will eventually occur”.6
+Oxford philosopher Nick Bostrom [writes that](https://www.nickbostrom.com/astronomical/waste.pdf) “With very advanced technology, a very large population of people living happy lives could be sustained in the accessible region of the universe. For every year that development of such technologies and colonization of the universe is delayed, there is therefore a corresponding opportunity cost: a potential good, lives worth living, is not being realized”.[^5] He coined the term “astronomical waste” to describe this opportunity cost of delayed technological development. Bostrom argues that, despite this large opportunity cost, utilitarians should not aim to maximize the rate of technological progress “but rather that we ought to maximize its safety, i.e. the probability that colonization will eventually occur”.[^6]
 
 See also: [Existential risk reduction](/acting-on-utilitarianism#existential-risk-reduction)
 
@@ -69,7 +69,7 @@ _→ Main article:_ [_Average view (population ethics)_](/population-ethics#the-
 
 The average view of population ethics regards one outcome as better than another if and only if it contains greater average wellbeing. Since the average view aims only to improve the average wellbeing level, it disregards—in contrast to [the total view](/population-ethics#the-total-view)—the number of individuals that exist. The average view avoids the [repugnant conclusion](/population-ethics#objecting-to-the-total-view), because it states that reductions in the average wellbeing level can never be compensated for by adding more people to the population.
 
-However, the average view has very little support among moral philosophers, because it leads to counterintuitive implications which are said to be at least as serious as the repugnant conclusion.7 For instance, drawing on the work of Derek Parfit8, Gustaf Arrhenius et al. (2017) writes that the average view implies the following: “\[F\]or a population consisting of just one person leading a life at a very negative level of well-being, e.g., a life of constant torture, there is another population which is better even though it contains millions of lives at just a slightly less negative level of well-being”.9
+However, the average view has very little support among moral philosophers, because it leads to counterintuitive implications which are said to be at least as serious as the repugnant conclusion.[^7] For instance, drawing on the work of Derek Parfit[^8], Gustaf Arrhenius et al. (2017) writes that the average view implies the following: “\[F\]or a population consisting of just one person leading a life at a very negative level of well-being, e.g., a life of constant torture, there is another population which is better even though it contains millions of lives at just a slightly less negative level of well-being”.[^9]
 
 The main alternatives to the average view of population ethics are the [_total view_](/population-ethics#the-total-view) and [_person-affecting views_](/population-ethics#person-affecting-views-and-the-procreative-asymmetry). According to the total view, one outcome is better than another if and only if it contains a greater sum total of wellbeing, even if that is in virtue of simply having more people. Person-affecting views are a family of views that share the intuition that an act can only be good or bad if it is good or bad _for_ someone. Standard person-affecting views stand in opposition to the total view, since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
 
@@ -82,7 +82,7 @@ _→ Main article:_ [_Career choice_](/acting-on-utilitarianism#career-choice)
 
 Most of us will spend around 80,000 hours during our lives on our professional careers, and some careers achieve much more good than others. Your choice of career is, therefore, one of the most important moral choices of your life. By using this time to address the most pressing global problems, we can do an enormous amount of good. Yet, it is far from obvious which careers will allow you to do the most good from a utilitarian perspective.
 
-Fortunately, there is research available to help us make more informed choices. The organization [80,000 Hours](https://80000hours.org/)10 aims to help people use their careers to solve the world’s most pressing problems. To do this, they research how individuals can maximize the social impact of their careers, create online advice, and support readers who might enter priority areas.
+Fortunately, there is research available to help us make more informed choices. The organization [80,000 Hours](https://80000hours.org/)[^10] aims to help people use their careers to solve the world’s most pressing problems. To do this, they research how individuals can maximize the social impact of their careers, create online advice, and support readers who might enter priority areas.
 
 </details>
 
@@ -91,7 +91,7 @@ Fortunately, there is research available to help us make more informed choices. 
 
 [Cause impartiality](/utilitarianism-and-practical-ethics#cause-impartiality) is the view that one’s choice of social cause to focus on should depend on, and only on, the expected amount of good that one can do in that cause. Which causes will allow us to do the greatest amount of good by promoting wellbeing? Finding the answer to that question is called [cause prioritization](/acting-on-utilitarianism#cause-prioritization).
 
-We know that some ways of benefiting individuals do much more good than others. For example, within the cause of [global health and development](/acting-on-utilitarianism#global-health-and-development), some interventions are over 100 times as effective as others.11 Furthermore, many researchers believe that the difference in expected impact among _causes_ is as great as the differences among _interventions within a particular cause_. If so, focusing on the very best causes is vastly more impactful than focusing on average ones.
+We know that some ways of benefiting individuals do much more good than others. For example, within the cause of [global health and development](/acting-on-utilitarianism#global-health-and-development), some interventions are over 100 times as effective as others.[^11] Furthermore, many researchers believe that the difference in expected impact among _causes_ is as great as the differences among _interventions within a particular cause_. If so, focusing on the very best causes is vastly more impactful than focusing on average ones.
 
 </details>
 
@@ -102,9 +102,9 @@ _→ Main article:_ [_Charitable giving_](/acting-on-utilitarianism#charitable-g
 
 In slogan form, the utilitarian recommendation for using your money to help others is to “give more and give better”. Giving more simply means increasing the proportion of your income you give to charity. Giving better means finding and donating to the organizations that make the best use of your donation.
 
-Citizens of affluent countries are in the richest few percent of the world’s population. By making small sacrifices, those in the affluent world have the power to dramatically improve the lives of others. Due to the extreme inequalities in wealth and income, one can do a lot more good by giving money to those most in need than by spending it on oneself.12
+Citizens of affluent countries are in the richest few percent of the world’s population. By making small sacrifices, those in the affluent world have the power to dramatically improve the lives of others. Due to the extreme inequalities in wealth and income, one can do a lot more good by giving money to those most in need than by spending it on oneself.[^12]
 
-To give better, one can follow the recommendations from organizations such as [GiveWell](https://www.givewell.org/), which conducts exceptionally in-depth charity evaluations. GiveWell’s best-guess estimate is that the most cost-effective charities working in global health can save a child’s life for about $3,000.13
+To give better, one can follow the recommendations from organizations such as [GiveWell](https://www.givewell.org/), which conducts exceptionally in-depth charity evaluations. GiveWell’s best-guess estimate is that the most cost-effective charities working in global health can save a child’s life for about $3,000.[^13]
 
 </details>
 
@@ -152,7 +152,7 @@ _→ Main article:_ [_Demandingness_](/utilitarianism-and-practical-ethics#deman
 
 Utilitarianism is a very demanding ethical theory: it maintains that any time you can do more to help other people than you can to help yourself, you should do so. For example, if you could sacrifice your life to save the lives of several other people then, other things being equal, according to utilitarianism, you ought to do so.
 
-Though occasions where sacrificing your own life is the best thing to do are rare, utilitarianism is still very demanding in the world today. For example, by [donating to a highly effective global health charity](/acting-on-utilitarianism#charitable-giving), you can save a child’s life for just a few thousand dollars.14 As long as such donations benefit others more than a few thousand dollars would benefit yourself—as they almost certainly do, if you are a typical citizen of an affluent country—you ought to donate. Indeed, you likely ought to donate the majority of your lifetime income.
+Though occasions where sacrificing your own life is the best thing to do are rare, utilitarianism is still very demanding in the world today. For example, by [donating to a highly effective global health charity](/acting-on-utilitarianism#charitable-giving), you can save a child’s life for just a few thousand dollars.[^14] As long as such donations benefit others more than a few thousand dollars would benefit yourself—as they almost certainly do, if you are a typical citizen of an affluent country—you ought to donate. Indeed, you likely ought to donate the majority of your lifetime income.
 
 As well as requiring very significant donations, utilitarianism claims that you ought to [choose whatever career will most benefit others](/acting-on-utilitarianism#career-choice), too. This might involve non-profit work, conducting important research, or going into politics or advocacy.
 
@@ -167,7 +167,7 @@ _→ Main article:_ [_Demandingness objection to utilitarianism_](/objections-to
 
 Many critics argue that utilitarianism is too demanding, because it requires us to always act such as to bring about the best outcome. The theory leaves no room for actions that are permissible yet do not bring about the best consequences; this is why some critics claim that utilitarianism is a morality only for saints.
 
-Consider that the money a person spends on dining out could pay for several bednets, each protecting two children in a low-income country from malaria for about two years.15 From a utilitarian perspective, the benefit to the person from dining out is much smaller than the benefit to the children from not having malaria, so it would seem the person has acted wrongly in choosing to have a meal out. Analogous reasoning applies to how we use our time: the hours someone spends on social media should apparently be spent volunteering for a charity, or working harder at one’s job to earn more money to donate.
+Consider that the money a person spends on dining out could pay for several bednets, each protecting two children in a low-income country from malaria for about two years.[^15] From a utilitarian perspective, the benefit to the person from dining out is much smaller than the benefit to the children from not having malaria, so it would seem the person has acted wrongly in choosing to have a meal out. Analogous reasoning applies to how we use our time: the hours someone spends on social media should apparently be spent volunteering for a charity, or working harder at one’s job to earn more money to donate.
 
 See the article [The Demandingness Objection](/objections-to-utilitarianism/demandingness) on how proponents of utilitarianism might respond to this objection.
 
@@ -176,7 +176,7 @@ See the article [The Demandingness Objection](/objections-to-utilitarianism/dema
 <details>
 <summary>Deontology<span class="icon"></span></summary>
 
-According to _deontology_, morality is about following a system of duties and rules, like “Do Not Lie” or “Do Not Steal”. As Larry Alexander and Michael Moore [write](https://plato.stanford.edu/entries/ethics-deontological/): “In contrast to consequentialist theories, deontological theories judge the morality of choices by criteria different from the states of affairs those choices bring about. The most familiar forms of deontology, and also the forms presenting the greatest contrast to consequentialism, hold that some choices cannot be justified by their effects—that no matter how morally good their consequences, some choices are morally forbidden”.16
+According to _deontology_, morality is about following a system of duties and rules, like “Do Not Lie” or “Do Not Steal”. As Larry Alexander and Michael Moore [write](https://plato.stanford.edu/entries/ethics-deontological/): “In contrast to consequentialist theories, deontological theories judge the morality of choices by criteria different from the states of affairs those choices bring about. The most familiar forms of deontology, and also the forms presenting the greatest contrast to consequentialism, hold that some choices cannot be justified by their effects—that no matter how morally good their consequences, some choices are morally forbidden”.[^16]
 
 The main alternatives to deontology are [_consequentialism_](/types-of-utilitarianism#consequentialism), the view that the moral rightness of actions (or rules, policies, etc.) depends on, and only on, the value of their consequences, and [_virtue ethics_](https://plato.stanford.edu/entries/ethics-virtue/), according to which morality is fundamentally about having or developing a virtuous character.
 
@@ -222,7 +222,7 @@ However, while consequentialists—including utilitarians—accept that doing ha
 
 _→ Main article:_ [_Effective altruism_](/acting-on-utilitarianism#effective-altruism)
 
-Those in the [effective altruism](https://www.effectivealtruism.org/) movement try to figure out, of all the different uses of our resources, which ones will do the most good, impartially considered, and act on that basis. So defined, effective altruism is both a research project—to figure out how to do the most good—and a practical project to implement the best guesses we have about how to do the most good.17
+Those in the [effective altruism](https://www.effectivealtruism.org/) movement try to figure out, of all the different uses of our resources, which ones will do the most good, impartially considered, and act on that basis. So defined, effective altruism is both a research project—to figure out how to do the most good—and a practical project to implement the best guesses we have about how to do the most good.[^17]
 
 </details>
 
@@ -268,7 +268,7 @@ See the article [The Equality Objection](/objections-to-utilitarianism/equality)
 
 _→ Main article:_ [_Existential risk reduction_](/acting-on-utilitarianism#existential-risk-reduction)
 
-An existential risk is a risk that threatens the destruction of humanity’s long-term potential—such as all-out nuclear war, or extreme climate change, or an engineered global pandemic.18 From a utilitarian perspective (and the perspective of many other moral views), the realization of an existential risk would be uniquely bad and much worse than non-existential catastrophes. Besides the deaths of all 7.8 billion people on this planet, an existential catastrophe would irreversibly deprive humanity of a potentially grand future and preclude trillions of lives to come. Since the stakes involved with existential risks are so large, their mitigation may, therefore, be one of the most important moral issues we face.
+An existential risk is a risk that threatens the destruction of humanity’s long-term potential—such as all-out nuclear war, or extreme climate change, or an engineered global pandemic.[^18] From a utilitarian perspective (and the perspective of many other moral views), the realization of an existential risk would be uniquely bad and much worse than non-existential catastrophes. Besides the deaths of all 7.8 billion people on this planet, an existential catastrophe would irreversibly deprive humanity of a potentially grand future and preclude trillions of lives to come. Since the stakes involved with existential risks are so large, their mitigation may, therefore, be one of the most important moral issues we face.
 
 _External links:_ [The Precipice: Existential Risk and the Future of Humanity](https://theprecipice.com/), Toby Ord (2020)
 
@@ -279,7 +279,7 @@ _External links:_ [The Precipice: Existential Risk and the Future of Humanity](h
 
 _→ Main article:_ [_The expanding moral circle_](/utilitarianism-and-practical-ethics#the-expanding-moral-circle)
 
-We now recognize that characteristics like race, gender, and sexual orientation do not justify discriminating against individuals or disregarding their suffering. Over time, our society has gradually expanded our moral concern to ever more groups, a trend of moral progress often called the _expanding moral circle_.19 But what are the limits of this trend?
+We now recognize that characteristics like race, gender, and sexual orientation do not justify discriminating against individuals or disregarding their suffering. Over time, our society has gradually expanded our moral concern to ever more groups, a trend of moral progress often called the _expanding moral circle_.[^19] But what are the limits of this trend?
 
 Utilitarianism provides a clear response to this question: We should extend our moral concern to all _sentient beings_, meaning every individual capable of experiencing positive or negative conscious states. This includes humans and probably many non-human animals, but not plants or other entities that are non-sentient. This view is sometimes called _sentiocentrism_ as it regards sentience as the characteristic that entitles individuals to moral concern.
 
@@ -292,7 +292,7 @@ A priority for utilitarians may be to help society to continue to widen its mora
 
 _→ Main article:_ [_Expectational utilitarianism_](/types-of-utilitarianism#expectational-utilitarianism-versus-objective-utilitarianism)
 
-Expectational utilitarianism is the view we should promote _expected_ wellbeing, as opposed to the wellbeing an action will _in fact_ produce. Expectational utilitarianism states we should choose the actions with the highest expected value.20 The expected value of an action is the sum of the value of each of the potential outcomes multiplied by the probability of that outcome occurring. So, for example, according to expectational utilitarianism, we should choose a 10% chance of saving 1,000 lives over a 50% chance of saving 150 lives because the former option saves an expected 100 lives (= 10% \* 1,000 lives) whereas the latter option saves an expected 75 lives (= 50% \* 150 lives).
+Expectational utilitarianism is the view we should promote _expected_ wellbeing, as opposed to the wellbeing an action will _in fact_ produce. Expectational utilitarianism states we should choose the actions with the highest expected value.[^20] The expected value of an action is the sum of the value of each of the potential outcomes multiplied by the probability of that outcome occurring. So, for example, according to expectational utilitarianism, we should choose a 10% chance of saving 1,000 lives over a 50% chance of saving 150 lives because the former option saves an expected 100 lives (= 10% \* 1,000 lives) whereas the latter option saves an expected 75 lives (= 50% \* 150 lives).
 
 The main alternative to expectational utilitarianism is _objective utilitarianism_, on which the rightness of an action depends on the wellbeing it will _in fact_ produce.
 
@@ -312,7 +312,7 @@ Improving the welfare of farmed animals should be a high moral priority for util
 
 _→ Main article:_ [_Global health and development_](/acting-on-utilitarianism#global-health-and-development)
 
-Efforts in global health and development have a great track record of improving lives, making this cause appear especially tractable. Indeed, the best interventions in global health and development are incredibly cost-effective: [GiveWell](https://www.givewell.org/), a leading organization that conducts in-depth charity evaluations, estimates that top-rated charities can prevent the death of a child from malaria for just a few thousand dollars by providing preventive drugs.21 On this basis, global health and development may be considered a particularly high priority cause for utilitarians.22
+Efforts in global health and development have a great track record of improving lives, making this cause appear especially tractable. Indeed, the best interventions in global health and development are incredibly cost-effective: [GiveWell](https://www.givewell.org/), a leading organization that conducts in-depth charity evaluations, estimates that top-rated charities can prevent the death of a child from malaria for just a few thousand dollars by providing preventive drugs.[^21] On this basis, global health and development may be considered a particularly high priority cause for utilitarians.[^22]
 
 </details>
 
@@ -323,7 +323,7 @@ _→ Main article:_ [_Global utilitarianism_](/types-of-utilitarianism#global-ut
 
 Global utilitarianism is the view that the utilitarian standards of right and wrong can evaluate anything of interest, including actions, motives, rules, virtues, policies, social institutions, etc.
 
-Global utilitarianism assesses the moral nature of, for example, a particular character trait, such as kindness or loyalty, based on the consequences that trait has for the wellbeing of others—just as act utilitarianism evaluates the rightness of actions. Global utilitarianism's broad focus may help it to explain certain supposedly "non-consequentialist" intuitions.23 For instance, it captures the understanding that morality is not just about choosing the right acts but is also about following certain rules and developing a virtuous character.
+Global utilitarianism assesses the moral nature of, for example, a particular character trait, such as kindness or loyalty, based on the consequences that trait has for the wellbeing of others—just as act utilitarianism evaluates the rightness of actions. Global utilitarianism's broad focus may help it to explain certain supposedly "non-consequentialist" intuitions.[^23] For instance, it captures the understanding that morality is not just about choosing the right acts but is also about following certain rules and developing a virtuous character.
 
 </details>
 
@@ -348,9 +348,9 @@ Harriet Taylor Mill (1807 - 1858) was a British philosopher and women’s rights
 <details>
 <summary>Hedonic calculus<span class="icon"></span></summary>
 
-[Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) proposed the hedonic calculus, or felicific calculus, as a method to determine the goodness and badness of an action’s consequences.24 Bentham suggested that in assessing these consequences, one should take into account their _intensity, duration, certainty, propinquity, fecundity_ (the chance that a pleasure is followed by other ones, a pain by further pains)_, purity_ (the chance that pleasure is followed by pains and vice versa), and _extent_ (the number of persons affected). Applying the hedonic calculus to similarly assess all the alternative actions, would show which one has the best overall consequences, and should therefore be chosen.
+[Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) proposed the hedonic calculus, or felicific calculus, as a method to determine the goodness and badness of an action’s consequences.[^24] Bentham suggested that in assessing these consequences, one should take into account their _intensity, duration, certainty, propinquity, fecundity_ (the chance that a pleasure is followed by other ones, a pain by further pains)_, purity_ (the chance that pleasure is followed by pains and vice versa), and _extent_ (the number of persons affected). Applying the hedonic calculus to similarly assess all the alternative actions, would show which one has the best overall consequences, and should therefore be chosen.
 
-However, Bentham was realistic about the limitations of this method, writing that “it is not to be expected that this process \[of calculating expected consequences\] should be strictly pursued previously to every moral judgment”.25
+However, Bentham was realistic about the limitations of this method, writing that “it is not to be expected that this process \[of calculating expected consequences\] should be strictly pursued previously to every moral judgment”.[^25]
 
 </details>
 
@@ -372,7 +372,7 @@ The two main alternatives to hedonism are [_desire theories_](/theories-of-wellb
 
 _→ Main article:_ [_Henry Sidgwick_](/utilitarian-thinker/henry-sidgwick)
 
-Henry Sidgwick (1838 - 1900) was a British philosopher and economist. One of the classical utilitarians, he wrote one of the most important statements of utilitarianism in his [The Methods of Ethics](https://www.earlymoderntexts.com/assets/pdfs/sidgwick1874.pdf), which was said to be “the best book ever written on ethics”.26
+Henry Sidgwick (1838 - 1900) was a British philosopher and economist. One of the classical utilitarians, he wrote one of the most important statements of utilitarianism in his [The Methods of Ethics](https://www.earlymoderntexts.com/assets/pdfs/sidgwick1874.pdf), which was said to be “the best book ever written on ethics”.[^26]
 
 </details>
 
@@ -410,7 +410,7 @@ The main alternative to indirect consequentialism is direct consequentialism, ac
 <details>
 <summary>Infinite ethics<span class="icon"></span></summary>
 
-[In a 2011 paper](https://www.nickbostrom.com/ethics/infinite.html), Nick Bostrom suggests that infinities in ethics may present a problem for aggregative consequentialist theories, including utilitarianism. Bostrom describes this problem as follows: “Modern cosmology teaches that the world might well contain an infinite number of happy and sad people and other candidate value-bearing locations. Aggregative ethics implies that such a world contains an infinite amount of positive value and an infinite amount of negative value. You can affect only a finite amount of good or bad. In standard cardinal arithmetic, an infinite quantity is unchanged by the addition or subtraction of any finite quantity. So it appears you cannot change the value of the world”.27
+[In a 2011 paper](https://www.nickbostrom.com/ethics/infinite.html), Nick Bostrom suggests that infinities in ethics may present a problem for aggregative consequentialist theories, including utilitarianism. Bostrom describes this problem as follows: “Modern cosmology teaches that the world might well contain an infinite number of happy and sad people and other candidate value-bearing locations. Aggregative ethics implies that such a world contains an infinite amount of positive value and an infinite amount of negative value. You can affect only a finite amount of good or bad. In standard cardinal arithmetic, an infinite quantity is unchanged by the addition or subtraction of any finite quantity. So it appears you cannot change the value of the world”.[^27]
 
 </details>
 
@@ -437,7 +437,7 @@ John Stuart Mill (1806 - 1873) was a British philosopher and political economist
 
 _→ Main article:_ [_Longtermism_](/utilitarianism-and-practical-ethics#longtermism)
 
-Strong longtermism is the view that the most important determinant of the value of our actions today is how those actions affect the very long-run future. Strong longtermism is implied by most plausible forms of utilitarianism28 if we assume that some of our actions can meaningfully affect the long-term future and that we can estimate which effects are positive and which negative. A key reason why most utilitarians would endorse strong longtermism is that they accept _temporal_ [_impartiality_](/types-of-utilitarianism#impartiality), the view that the wellbeing of future generations is no less important simply because they are far away in time than the wellbeing of those alive today.
+Strong longtermism is the view that the most important determinant of the value of our actions today is how those actions affect the very long-run future. Strong longtermism is implied by most plausible forms of utilitarianism[^28] if we assume that some of our actions can meaningfully affect the long-term future and that we can estimate which effects are positive and which negative. A key reason why most utilitarians would endorse strong longtermism is that they accept _temporal_ [_impartiality_](/types-of-utilitarianism#impartiality), the view that the wellbeing of future generations is no less important simply because they are far away in time than the wellbeing of those alive today.
 
 An implication of strong longtermism is to take [existential risk reduction](/acting-on-utilitarianism#existential-risk-reduction) very seriously as a moral priority.
 
@@ -457,7 +457,7 @@ Maximizing utilitarianism is the view that within any set of options, the action
 
 Though this is the most common statement of utilitarianism, it may be misleading in some respects. Utilitarians agree that you _ideally_ ought to choose whatever action would best promote overall well-being. That's what you have the _most_ moral reason to do. But they do not recommend blaming you every time you fall short of this ideal. As a result, many utilitarians consider it misleading to take their claims about what ideally ought to be done as providing an account of moral "rightness" or "obligation" in the ordinary sense.
 
-The main alternatives to maximizing utilitarianism include _scalar utilitarianism_, according to which rightness and wrongness are matters of degree29, and _satisficing utilitarianism_, which holds that within any set of options, an action is right if it produces _enough_ wellbeing.30
+The main alternatives to maximizing utilitarianism include _scalar utilitarianism_, according to which rightness and wrongness are matters of degree[^29], and _satisficing utilitarianism_, which holds that within any set of options, an action is right if it produces _enough_ wellbeing.[^30]
 
 </details>
 
@@ -486,7 +486,7 @@ The main alternative to multi-level utilitarianism is _single-level utilitariani
 <details>
 <summary>Negative utilitarianism<span class="icon"></span></summary>
 
-Negative utilitarianism is a version of utilitarianism that assigns either no (at its most extreme) or considerably less (in its moderate form) value to the promotion of happiness relative to the reduction of suffering. One of the earliest academic formulations and critiques of negative utilitarianism was made by R. N. Smart in response to Karl Popper.31
+Negative utilitarianism is a version of utilitarianism that assigns either no (at its most extreme) or considerably less (in its moderate form) value to the promotion of happiness relative to the reduction of suffering. One of the earliest academic formulations and critiques of negative utilitarianism was made by R. N. Smart in response to Karl Popper.[^31]
 
 _External links:_
 
@@ -564,7 +564,7 @@ Other utilitarians may accept a different theory of well-being, such as hedonism
 <details>
 <summary>Principle of utility<span class="icon"></span></summary>
 
-In his main work _An Introduction to the Principles of Morals and Legislation_, [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) calls the core idea at the heart of his utilitarian philosophy the _principle of utility_. He describes it as follows: “By the ‘principle of utility’ is meant the principle that approves or disapproves of every action according to the tendency it appears to have to increase or lessen—i.e. to promote or oppose—the happiness of the person or group whose interest is in question”.32
+In his main work _An Introduction to the Principles of Morals and Legislation_, [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) calls the core idea at the heart of his utilitarian philosophy the _principle of utility_. He describes it as follows: “By the ‘principle of utility’ is meant the principle that approves or disapproves of every action according to the tendency it appears to have to increase or lessen—i.e. to promote or oppose—the happiness of the person or group whose interest is in question”.[^32]
 
 </details>
 
@@ -639,7 +639,7 @@ Satisficing utilitarianism is the view that within any set of options, an action
 
 However, this proposal has some problems and has not found wide support. To see this, suppose that Sophie could save no one, or save 999 people at great personal sacrifice, or save 1,000 people at even greater personal sacrifice. From the utilitarian’s perspective, we still want to say there is reason to save the 1,000 people over the 999 people; labeling both actions as _right_ would risk ignoring the important moral difference between these two options.
 
-The main alternatives to satisficing utilitarianism are _scalar utilitarianism_, according to which rightness and wrongness are matters of degree33, and _maximizing utilitarianism_, the view that within any set of options, the action that produces the most wellbeing is right, and all other actions are wrong.
+The main alternatives to satisficing utilitarianism are _scalar utilitarianism_, according to which rightness and wrongness are matters of degree[^33], and _maximizing utilitarianism_, the view that within any set of options, the action that produces the most wellbeing is right, and all other actions are wrong.
 
 _External links:_
 
@@ -654,7 +654,7 @@ _External links:_
 
 _→ Main article:_ [_Scalar versus maximizing or satisficing utilitarianism_](/types-of-utilitarianism#scalar-versus-maximizing-or-satisficing-utilitarianism)
 
-Scalar utilitarianism is the view that moral evaluation is a matter of degree: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.34 On this view, there is no fundamental, sharp distinction between 'right' and 'wrong' actions, just a continuous scale from morally better to worse.
+Scalar utilitarianism is the view that moral evaluation is a matter of degree: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.[^34] On this view, there is no fundamental, sharp distinction between 'right' and 'wrong' actions, just a continuous scale from morally better to worse.
 
 The main alternatives to scalar utilitarianism are _maximizing utilitarianism_, the view that within any set of options, the action that produces the most wellbeing is right, and all other actions are wrong, and _satisficing utilitarianism_, according to which within any set of options, an action is right if it produces _enough_ wellbeing.
 
@@ -685,7 +685,7 @@ _→ Main article:_ [_Multi-level utilitarianism versus single-level utilitarian
 
 Single-level utilitarianism is the view that utilitarianism should be understood as both a criterion of rightness and a decision procedure. A criterion of rightness tells us what it takes for an action (or rule, policy, etc.) to be right or wrong. A decision procedure is something that we use when thinking about what to do.
 
-To our knowledge, no one has ever defended single-level utilitarianism, including the classical utilitarians.35 Deliberately calculating the expected consequences of all our actions is error-prone and risks falling into decision paralysis.
+To our knowledge, no one has ever defended single-level utilitarianism, including the classical utilitarians.[^35] Deliberately calculating the expected consequences of all our actions is error-prone and risks falling into decision paralysis.
 
 The main alternative to single-level utilitarianism is _multi-level utilitarianism_, the view that individuals should usually follow tried-and-tested rules of thumb, or _heuristics_, rather than trying to calculate which action will produce the most wellbeing. Thus, multi-level utilitarianism understands utilitarianism as a criterion of rightness, not as a decision procedure.
 
@@ -729,7 +729,7 @@ The total view of population ethics regards one outcome as better than another i
 
 Importantly, one population may have greater total wellbeing than another in virtue of having more people. One way to calculate this total is to multiply the number of individuals with their average quality of life. For example, the total view regards a world with 100 inhabitants at average wellbeing level 10 as just as good as another world with 200 inhabitants at wellbeing level 5—both worlds contain 1,000 units of wellbeing.
 
-Thus, the total view implies that we can improve the world in two ways: either we improve the quality of life of existing people or we increase the number of people living positive lives. So, for example, the total view regards having a child that lives a happy and fulfilled life as something that makes the world better, other things being equal, since it adds to the total sum of wellbeing.36 In practice, there are often trade-offs between making existing people happier and creating additional happy people. On a planet with limited resources, adding more people to an already large population may at some point diminish the quality of life of everyone else severely enough that total wellbeing decreases.
+Thus, the total view implies that we can improve the world in two ways: either we improve the quality of life of existing people or we increase the number of people living positive lives. So, for example, the total view regards having a child that lives a happy and fulfilled life as something that makes the world better, other things being equal, since it adds to the total sum of wellbeing.[^36] In practice, there are often trade-offs between making existing people happier and creating additional happy people. On a planet with limited resources, adding more people to an already large population may at some point diminish the quality of life of everyone else severely enough that total wellbeing decreases.
 
 The total view’s foremost practical implication is [giving great importance](/utilitarianism-and-practical-ethics#longtermism) to ensuring the long-term flourishing of civilization. Since the total wellbeing enjoyed by all future people is potentially enormous, according to the total view, the [mitigation of existential risks](/acting-on-utilitarianism#existential-risk-reduction)—which threaten to destroy this immense future value—is one of the principal moral issues facing humanity.
 
@@ -748,7 +748,7 @@ Greaves, H. (2017). [Population Axiology](https://doi.org/10.1111/phc3.12442). _
 
 _→ Main article:_ [_Utilitarianism_](/introduction-to-utilitarianism#explaining-what-utilitarianism-is)
 
-Utilitarianism is the view that one morally ought to promote just the sum total of well-being.37 The four elements shared by all utilitarian theories include (i) [consequentialism](/types-of-utilitarianism#consequentialism), (ii) [welfarism](/types-of-utilitarianism#welfarism), (iii) [impartiality](/types-of-utilitarianism#impartiality), and (iv) [aggregationism](/types-of-utilitarianism#aggregationism).
+Utilitarianism is the view that one morally ought to promote just the sum total of well-being.[^37] The four elements shared by all utilitarian theories include (i) [consequentialism](/types-of-utilitarianism#consequentialism), (ii) [welfarism](/types-of-utilitarianism#welfarism), (iii) [impartiality](/types-of-utilitarianism#impartiality), and (iv) [aggregationism](/types-of-utilitarianism#aggregationism).
 
 </details>
 
@@ -764,7 +764,7 @@ In contemporary contexts, utility is predominantly used as an economic concept (
 <details>
 <summary>Utility monster<span class="icon"></span></summary>
 
-The utility monster is a thought experiment devised by Robert Nozick to criticize utilitarianism.38 Nozick imagines a hypothetical being, the utility monster, which has the capacity for generating much higher levels of wellbeing than anyone else. From a utilitarian perspective, Nozick writes, the existence of such a being would require providing it with immense resources to increase its wellbeing, even at significant sacrifice to others.
+The utility monster is a thought experiment devised by Robert Nozick to criticize utilitarianism.[^38] Nozick imagines a hypothetical being, the utility monster, which has the capacity for generating much higher levels of wellbeing than anyone else. From a utilitarian perspective, Nozick writes, the existence of such a being would require providing it with immense resources to increase its wellbeing, even at significant sacrifice to others.
 
 For a utilitarian critique, see:
 

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -820,37 +820,39 @@ _External links:_ [Well-being](https://plato.stanford.edu/entries/well-being/), 
 
 [^5]: Bostrom, N. (2003. [Astronomical Waste: The Opportunity Cost of Delayed Technological Development](https://www.nickbostrom.com/astronomical/waste.pdf). _Utilitas_. 15(3), 308–314.
 [^6]: Bostrom, N. (2003. [Astronomical Waste: The Opportunity Cost of Delayed Technological Development](https://www.nickbostrom.com/astronomical/waste.pdf). _Utilitas_. 15(3), 308–314.
-[^7]: Note that Professor William MacAskill, coauthor of this website, is a cofounder of [80,000 Hours](https://80000hours.org/).
-[^8]: Ord, T. (2019). [The Moral Imperative Towards Cost-Effectiveness in Global Health](https://www.givingwhatwecan.org/research/the-moral-imperative-towards-cost-effectiveness/)\_, In Effective Altruism: Philosophical Issues.\_Oxford: Oxford University Press.
-[^9]: Cf. MacAskill, W. (2014). [Doing Good Better: How Effective Altruism Can Help You Make a Difference](https://www.effectivealtruism.org/doing-good-better/). New York: Random House. Chapter 1. Note that Professor William MacAskill, coauthor of this website, is the author of _Doing Good Better_.
-[^10]: GiveWell (2019). [Your Dollar Goes Further Overseas](https://www.givewell.org/giving101/Your-dollar-goes-further-overseas).
-[^11]: <sup> </sup>GiveWell (2019). [Your dollar goes further overseas](https://www.givewell.org/giving101/Your-dollar-goes-further-overseas).
-[^12]: GiveWell (2019). [Against Malaria Foundation](https://www.givewell.org/charities/amf).
-[^13]: Alexander, L. & Moore, M. (2020). [Deontological Ethics](https://plato.stanford.edu/archives/win2020/entries/ethics-deontological/). The Stanford Encyclopedia of Philosophy. Zalta, E. N. (ed.).
-[^14]: For a detailed philosophical discussion of effective altruism, see the 16 articles included in Greaves, H. & Pummer, T. (2019). [Effective Altruism: Philosophical Issues](https://oxford.universitypressscholarship.com/view/10.1093/oso/9780198841364.001.0001/oso-9780198841364). Oxford: Oxford University Press.
-[^15]: Ord, T. (2020). [The Precipice: Existential Risk and the Future of Humanity](https://theprecipice.com/). London: Bloomsbury Publishing., p. 37
-[^16]: Cf. Singer, P. (1981). [The Expanding Circle: Ethics, Evolution, and Moral Progress](https://press.princeton.edu/books/paperback/9780691150697/the-expanding-circle). Princeton: Princeton University Press.
-[^17]: Anthis, J. & Paez, E. (2021). [Moral circle expansion: A promising strategy to impact the far future](https://doi.org/10.1016/j.futures.2021.102756). _Futures_, 130.
-[^18]: Utilitarians of any type understand “value” in terms of well-being.
-[^19]: GiveWell (2019). [Your Dollar Goes Further Overseas](https://www.givewell.org/giving101/Your-dollar-goes-further-overseas).
-[^20]: For instance, Peter Singer’s book [The Life You Can Save](https://www.thelifeyoucansave.org/the-book/) (the updated 10-year anniversary edition is available for free download) makes the case for the ethical importance of improving global health and international development.
-[^21]: For a discussion of global consequentialism, see (i) Pettit, P. & Smith, M. (2000). [Global Consequentialism](https://philarchive.org/archive/PETGC), in Brad Hooker, Elinor Mason & Dale Miller (eds.), _Morality, Rules and Consequences: A Critical Reader_. Edinburgh University Press; and (ii) Ord, T. (2009). [Beyond Action: Applying Consequentialism to Decision Making and Motivation](https://drive.google.com/open?id=0B4kMPIEI5Mb8S201Wl85NTN1UHc). DPhil Thesis, University of Oxford.
-[^22]: Bentham, J. (1789). Chapter IV: Value of a Lot of Pleasure or Pain, How to be Measured, In _[An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf)_.
-[^23]: Bentham, J. (1789). [An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf). Bennet, J. (ed.)., p. 23
-[^24]: Smart, J. J. C. (1956). [Extreme and Restricted Utilitarianism](http://personal.lse.ac.uk/robert49/teaching/mm/articles/Smart_1956Utilitarianism.pdf). _The Philosophical Quarterly_. 6(25)., p. 347.
-[^25]: Bostrom, N. (2011). [Infinite Ethics](https://www.nickbostrom.com/ethics/infinite.html). _Analysis and Metaphysics_. 10: 9–59.
-[^26]: Cf. Greaves, H. & MacAskill, W. (2019). [The Case for Strong Longtermism](https://globalprioritiesinstitute.org/hilary-greaves-william-macaskill-the-case-for-strong-longtermism/). _Global Priorities Institute_. Section 4.1. Note that Professor William MacAskill, coauthor of this website, is also a coauthor of this paper.
-[^27]: More precisely: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.
-[^28]: For a discussion of this view, see Slote, M. & Pettit, P. (1984). [Satisficing Consequentialism](https://www.princeton.edu/~ppettit/papers/1984/Satisficing%20Consequentialism.pdf). _Proceedings of the Aristotelian Society_, Supplementary Volumes. 58: 139–163 & 165–176.
-[^29]: Smart, R. N. (1958). [Negative Utilitarianism](https://doi.org/10.1093/mind/LXVII.268.542). _Mind_. 67(268): 542–43.
-[^30]: Bentham, J. (1789). [An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf). Bennet, J. (ed.)., p. 7
-[^31]: Parfit, D. (1997). [Equality and Priority](https://dx.doi.org/10.1111/1467-9329.00041). _Ratio_,10(3): 202–221, p. 213.
-[^32]: More precisely: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.
-[^33]: Norcross, A. (2020). _Morality by Degrees: Reasons Without Demands_. Oxford University Press.
-[^34]:
+[^7]: Greaves, H. (2017). [Population axiology](https://doi.org/10.1111/phc3.12442). _Philosophy Compass_. 12(11).
+[^8]: Parfit, D. (1984). 143. Why We Ought to Reject the Average Principle, in _[Reasons and Persons](https://en.wikipedia.org/wiki/Reasons_and_Persons)_. Oxford: Oxford University Press.
+[^9]: Arrhenius, G., Ryberg, J. & Tännsjö, T. (2017). [The Repugnant Conclusion](https://plato.stanford.edu/archives/spr2017/entries/repugnant-conclusion/). _The Stanford Encyclopedia of Philosophy_. Zalta, E. N. (ed.).
+[^10]: Note that Professor William MacAskill, coauthor of this website, is a cofounder of [80,000 Hours](https://80000hours.org/).
+[^11]: Ord, T. (2019). _[The Moral Imperative Towards Cost-Effectiveness in Global Health](https://www.givingwhatwecan.org/research/the-moral-imperative-towards-cost-effectiveness/)_, In Effective Altruism: Philosophical Issues. Oxford: Oxford University Press.
+[^12]: Cf. MacAskill, W. (2014). [Doing Good Better: How Effective Altruism Can Help You Make a Difference](https://www.effectivealtruism.org/doing-good-better/). New York: Random House. Chapter 1. Note that Professor William MacAskill, coauthor of this website, is the author of _Doing Good Better_.
+[^13]: GiveWell (2019). [Your Dollar Goes Further Overseas](https://www.givewell.org/giving101/Your-dollar-goes-further-overseas).
+[^14]: GiveWell (2019). [Your dollar goes further overseas](https://www.givewell.org/giving101/Your-dollar-goes-further-overseas).
+[^15]: GiveWell (2019). [Against Malaria Foundation](https://www.givewell.org/charities/amf).
+[^16]: Alexander, L. & Moore, M. (2020). [Deontological Ethics](https://plato.stanford.edu/archives/win2020/entries/ethics-deontological/). The Stanford Encyclopedia of Philosophy. Zalta, E. N. (ed.).
+[^17]: For a detailed philosophical discussion of effective altruism, see the 16 articles included in Greaves, H. & Pummer, T. (2019). [Effective Altruism: Philosophical Issues](https://oxford.universitypressscholarship.com/view/10.1093/oso/9780198841364.001.0001/oso-9780198841364). Oxford: Oxford University Press.
+[^18]: Ord, T. (2020). [The Precipice: Existential Risk and the Future of Humanity](https://theprecipice.com/). London: Bloomsbury Publishing., p. 37
+[^19]: Cf. Singer, P. (1981). _[The Expanding Circle: Ethics, Evolution, and Moral Progress](https://press.princeton.edu/books/paperback/9780691150697/the-expanding-circle)_. Princeton: Princeton University Press.
+[^20]: Utilitarians of any type understand “value” in terms of well-being.
+[^21]: GiveWell (2019). [Your dollar goes further overseas](https://www.givewell.org/giving101/Your-dollar-goes-further-overseas).
+[^22]: For instance, Peter Singer’s book [The Life You Can Save](https://www.thelifeyoucansave.org/the-book/) (the updated 10-year anniversary edition is available for free download) makes the case for the ethical importance of improving global health and international development.
+[^23]: For a discussion of global consequentialism, see (i) Pettit, P. & Smith, M. (2000). [Global Consequentialism](https://philarchive.org/archive/PETGC), in Brad Hooker, Elinor Mason & Dale Miller (eds.), _Morality, Rules and Consequences: A Critical Reader_. Edinburgh University Press; and (ii) Ord, T. (2009). [Beyond Action: Applying Consequentialism to Decision Making and Motivation](https://drive.google.com/open?id=0B4kMPIEI5Mb8S201Wl85NTN1UHc). DPhil Thesis, University of Oxford.
+[^24]: Bentham, J. (1789). Chapter IV: Value of a Lot of Pleasure or Pain, How to be Measured, In _[An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf)_.
+[^25]: Bentham, J. (1789). [An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf). Bennet, J. (ed.)., p. 23
+[^26]: Smart, J. J. C. (1956). [Extreme and Restricted Utilitarianism](http://personal.lse.ac.uk/robert49/teaching/mm/articles/Smart_1956Utilitarianism.pdf). _The Philosophical Quarterly_. 6(25)., p. 347.
+[^27]: Bostrom, N. (2011). [Infinite Ethics](https://www.nickbostrom.com/ethics/infinite.html). _Analysis and Metaphysics_. 10: 9–59.
+[^28]: Cf. Greaves, H. & MacAskill, W. (2019). [The Case for Strong Longtermism](https://globalprioritiesinstitute.org/hilary-greaves-william-macaskill-the-case-for-strong-longtermism/). _Global Priorities Institute_. Section 4.1. Note that Professor William MacAskill, coauthor of this website, is also a coauthor of this paper.
+[^29]: More precisely: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.
+[^30]: For a discussion of this view, see Slote, M. & Pettit, P. (1984). [Satisficing Consequentialism](https://www.princeton.edu/~ppettit/papers/1984/Satisficing%20Consequentialism.pdf). _Proceedings of the Aristotelian Society_, Supplementary Volumes. 58: 139–163 & 165–176.
+[^31]: Smart, R. N. (1958). [Negative Utilitarianism](https://doi.org/10.1093/mind/LXVII.268.542). _Mind_. 67(268): 542–43.
+[^32]: Bentham, J. (1789). [An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf). Bennet, J. (ed.)., p. 7
+[^33]: More precisely: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.
+[^34]: Norcross, A. (2020). _Morality by Degrees: Reasons Without Demands_. Oxford University Press.
+[^35]:
     Jeremy Bentham rejected single-level utilitarianism, writing that “it is not to be expected that this process [of calculating expected consequences] should be strictly pursued previously to every moral judgment.” Bentham, J. (1789). [An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf). Bennet, J. (ed.)., p. 23
+
     Henry Sidgwick concurs, writing that “the end that gives the criterion of rightness needn’t always be the end that we consciously aim at; and if experience shows that general happiness will be better achieved if men frequently act from motives other than pure universal philanthropy, those other motives are preferable on utilitarian principles”. Sidgwick, H. (1874). [The Methods of Ethics](https://www.earlymoderntexts.com/assets/pdfs/sidgwick1874.pdf). Bennet, J. (ed.)., p. 201
 
-[^35]: Whether or not we should have the child, however, depends also on whether this improves the total well-being more than improving the lives of existing people would, and on issues regarding resource constraints and overpopulation.
-[^36]: This definition applies to a fixed-population setting, where one’s actions do not affect the number or identity of people. There are utilitarian theories that differ in how they deal with variable-population settings. This is a technical issue, relevant to the discussion of [population ethics](https://en.wikipedia.org/wiki/Population_ethics).
-[^37]: Nozick, R. (1974). _[Anarchy, State, and Utopia](https://en.wikipedia.org/wiki/Anarchy,_State,_and_Utopia)_. Basic Books.
+[^36]: Whether or not we should have the child, however, depends also on whether this improves the total well-being more than improving the lives of existing people would, and on issues regarding resource constraints and overpopulation.
+[^37]: This definition applies to a fixed-population setting, where one’s actions do not affect the number or identity of people. There are utilitarian theories that differ in how they deal with variable-population settings. This is a technical issue, relevant to the discussion of [population ethics](https://en.wikipedia.org/wiki/Population_ethics).
+[^38]: Nozick, R. (1974). _[Anarchy, State, and Utopia](https://en.wikipedia.org/wiki/Anarchy,_State,_and_Utopia)_. Basic Books.

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -11,23 +11,23 @@ This page provides an overview with brief descriptions of key utilitarian terms 
 <details>
 <summary>Act utilitarianism<span class="icon"></span></summary>
 
-Act utilitarianism is the view that one morally ought to promote just the sum total of well-being.[^1] Act utilitarianism is the best known version of [direct consequentialism](/types-of-utilitarianism#consequentialism) and is often contrasted with _rule utilitarianism_, an indirect consequentialist view. Contemporary utilitarian philosophers often endorse [global utilitarianism](/types-of-utilitarianism#global-utilitarianism-versus-hybrid-utilitarianism), which emphasizes that utilitarian standards of moral evaluation apply to anything of interest (not just acts).[^2]
+Act utilitarianism is the view that one morally ought to promote just the sum total of well-being.1 Act utilitarianism is the best known version of [direct consequentialism](/types-of-utilitarianism#consequentialism) and is often contrasted with _rule utilitarianism_, an indirect consequentialist view. Contemporary utilitarian philosophers often endorse [global utilitarianism](/types-of-utilitarianism#global-utilitarianism), which emphasizes that utilitarian standards of moral evaluation apply to anything of interest (not just acts).2
 
 </details>
 
 <details>
 <summary>Aggregationism<span class="icon"></span></summary>
 
-_→ Main article: [Aggregationism](/types-of-utilitarianism#aggregationism)_
+_→ Main article:_ [_Aggregationism_](/types-of-utilitarianism#aggregationism)
 
-Aggregationism holds that the value of the world is the sum of the values of its parts, where these parts are local phenomena such as experiences, lives, or societies.[^3] When combined with welfarism and the equal consideration of interests, this view implies that we can meaningfully add up the well-being of different individuals, and use this total to determine which trade-offs are worth making. Aggregationism is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
+Aggregationism holds that the value of the world is the sum of the values of its parts, where these parts are local phenomena such as experiences, lives, or societies.3 When combined with welfarism and the equal consideration of interests, this view implies that we can meaningfully add up the well-being of different individuals, and use this total to determine which trade-offs are worth making. Aggregationism is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
 
 </details>
 
 <details>
 <summary>Arguments in favor of utilitarianism: theoretical virtues<span class="icon"></span></summary>
 
-_→ Main article:_ _[Arguments for utilitarianism](/arguments-for-utilitarianism)_
+_→ Main article:_ [_Arguments for utilitarianism_](/arguments-for-utilitarianism)
 
 Utilitarianism has strong theoretical virtues as an ethical theory. It is simple and clear, and it provides concrete implications for how to act in any situation.
 
@@ -36,7 +36,7 @@ Utilitarianism has strong theoretical virtues as an ethical theory. It is simple
 <details>
 <summary>Arguments in favor of utilitarianism: track record<span class="icon"></span></summary>
 
-_→ Main article: [Track Record](/introduction-to-utilitarianism#track-record)_
+_→ Main article:_ [_Arguments in favor of utilitarianism: Track record_](/introduction-to-utilitarianism#track-record)
 
 Utilitarian moral reasoning has a strong track record of contributing to humanity’s collective moral progress. The classical utilitarians of the 18th and 19th centuries—[Jeremy Bentham](/utilitarian-thinker/jeremy-bentham), [John Stuart Mill](/utilitarian-thinker/john-stuart-mill), and [Henry Sidgwick](/utilitarian-thinker/henry-sidgwick)—had social and political attitudes that were far ahead of their time. While the early proponents of utilitarianism were still far from getting everything right, their utilitarian reasoning led them to escape many of their time’s moral prejudices and develop more enlightened moral views. Utilitarianism enabled Bentham, Mill, and Sidgwick to make better moral “predictions” than those who endorsed alternative moral views. That is, utilitarianism led the early utilitarians to many conclusions which struck people as counterintuitive at the time but which most of us now understand as right. This provides us with some reason to expect that when today's "common sense" moral intuitions conflict with utilitarian conclusions, the latter are more likely to be correct. At the very least, checking our moral and political views against utilitarian principles may help us to avoid and overcome some of our own biases.
 
@@ -45,18 +45,18 @@ Utilitarian moral reasoning has a strong track record of contributing to humanit
 <details>
 <summary>Arguments in favor of utilitarianism: the veil of ignorance<span class="icon"></span></summary>
 
-_→ Main article:_ _[Arguments for utilitarianism: The Golden Rule, the Veil of Ignorance, and the Ideal Observer](/arguments-for-utilitarianism#the-golden-rule-the-veil-of-ignorance-and-the-ideal-observer)_
+_→ Main article:_ [_Arguments for utilitarianism: The Golden Rule, the Veil of Ignorance, and the Ideal Observer_](/arguments-for-utilitarianism#the-golden-rule-the-veil-of-ignorance-and-the-ideal-observer)
 
 Imagine you had to decide how to structure society from behind a [veil of ignorance](https://plato.stanford.edu/entries/original-position/). Behind this veil of ignorance, you know all the facts about each person’s circumstances in society—what their income is, how happy they are, how they are affected by social policies, and their preferences and likes. However, what you do not know is which of these people you are. You only know that you have an _equal chance_ of being any of these people. Imagine, now, that you are trying to act in a rational and self-interested way—you are just trying to do whatever is best for yourself. How would you structure society?
 
-Nobel Prize-winning economist John Harsanyi proved that in this situation you will structure society to promote the sum total of everyone’s well-being.[^4] In other words, if you are rational and acting in self-interest and were put behind the veil of ignorance, you would come to use some version of utilitarianism as the principle to decide about the structure and rules of society.
+Nobel Prize-winning economist John Harsanyi proved that in this situation you will structure society to promote the sum total of everyone’s wellbeing.4 In other words, if you are rational and acting in self-interest and were put behind the veil of ignorance, you would come to use some version of utilitarianism as the principle to decide about the structure and rules of society.
 
 </details>
 
 <details>
 <summary>Astronomical waste<span class="icon"></span></summary>
 
-Oxford philosopher Nick Bostrom [writes that](https://www.nickbostrom.com/astronomical/waste.pdf) “With very advanced technology, a very large population of people living happy lives could be sustained in the accessible region of the universe. For every year that development of such technologies and colonization of the universe is delayed, there is therefore a corresponding opportunity cost: a potential good, lives worth living, is not being realized”.[^5] He coined the term “astronomical waste” to describe this opportunity cost of delayed technological development. Bostrom argues that, despite this large opportunity cost, utilitarians should not aim to maximize the rate of technological progress “but rather that we ought to maximize its safety, i.e. the probability that colonization will eventually occur”.[^6]
+Oxford philosopher Nick Bostrom [writes that](https://www.nickbostrom.com/astronomical/waste.pdf) “With very advanced technology, a very large population of people living happy lives could be sustained in the accessible region of the universe. For every year that development of such technologies and colonization of the universe is delayed, there is therefore a corresponding opportunity cost: a potential good, lives worth living, is not being realized”.5 He coined the term “astronomical waste” to describe this opportunity cost of delayed technological development. Bostrom argues that, despite this large opportunity cost, utilitarians should not aim to maximize the rate of technological progress “but rather that we ought to maximize its safety, i.e. the probability that colonization will eventually occur”.6
 
 See also: [Existential risk reduction](/acting-on-utilitarianism#existential-risk-reduction)
 
@@ -65,75 +65,75 @@ See also: [Existential risk reduction](/acting-on-utilitarianism#existential-ris
 <details>
 <summary>Average view (population ethics)<span class="icon"></span></summary>
 
-_→ Main article: [Average view (population ethics)](/population-ethics#the-average-view)_
+_→ Main article:_ [_Average view (population ethics)_](/population-ethics#the-average-view)
 
-The average view of population ethics regards one outcome as better than another if and only if it contains greater average well-being. Since the average view aims only to improve the average well-being level, it disregards—in contrast to [the total view](/population-ethics#the-total-view)—the number of individuals that exist. The average view avoids the [repugnant conclusion](/population-ethics#objecting-to-the-total-view) because it states that reductions in the average well-being level can never be compensated for merely by adding more people to the population.
+The average view of population ethics regards one outcome as better than another if and only if it contains greater average wellbeing. Since the average view aims only to improve the average wellbeing level, it disregards—in contrast to [the total view](/population-ethics#the-total-view)—the number of individuals that exist. The average view avoids the [repugnant conclusion](/population-ethics#objecting-to-the-total-view), because it states that reductions in the average wellbeing level can never be compensated for by adding more people to the population.
 
-However, the average view has very little support among moral philosophers since it suffers from severe problems. Among other defects, the average view entails the _sadistic conclusion_: that it can sometimes be better to create lives with negative well-being than to create lives with positive well-being from the same starting point, all else equal. Adding a small number of tortured, miserable people to a population diminishes the average well-being less than adding a sufficiently large number of people whose lives are pretty good, yet below the existing average.
+However, the average view has very little support among moral philosophers, because it leads to counterintuitive implications which are said to be at least as serious as the repugnant conclusion.7 For instance, drawing on the work of Derek Parfit8, Gustaf Arrhenius et al. (2017) writes that the average view implies the following: “\[F\]or a population consisting of just one person leading a life at a very negative level of well-being, e.g., a life of constant torture, there is another population which is better even though it contains millions of lives at just a slightly less negative level of well-being”.9
 
-The main alternatives to the average view of population ethics are the _[total view](/population-ethics#the-total-view)_ and _[person-affecting views](/population-ethics#person-affecting-views-and-the-procreative-asymmetry)_. According to the total view, one outcome is better than another if and only if it contains a greater sum total of well-being, even if that is in virtue of simply having more people. Person-affecting views are a family of views that share the intuition that an act can only be good or bad if it is good or bad _for_ someone. Standard person-affecting views stand in opposition to the total view since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
+The main alternatives to the average view of population ethics are the [_total view_](/population-ethics#the-total-view) and [_person-affecting views_](/population-ethics#person-affecting-views-and-the-procreative-asymmetry). According to the total view, one outcome is better than another if and only if it contains a greater sum total of wellbeing, even if that is in virtue of simply having more people. Person-affecting views are a family of views that share the intuition that an act can only be good or bad if it is good or bad _for_ someone. Standard person-affecting views stand in opposition to the total view, since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
 
 </details>
 
 <details>
 <summary>Career choice<span class="icon"></span></summary>
 
-_→ Main article: [Career choice](/acting-on-utilitarianism#career-choice)_
+_→ Main article:_ [_Career choice_](/acting-on-utilitarianism#career-choice)
 
 Most of us will spend around 80,000 hours during our lives on our professional careers, and some careers achieve much more good than others. Your choice of career is, therefore, one of the most important moral choices of your life. By using this time to address the most pressing global problems, we can do an enormous amount of good. Yet, it is far from obvious which careers will allow you to do the most good from a utilitarian perspective.
 
-Fortunately, there is research available to help us make more informed choices. The organization [80,000 Hours](https://80000hours.org/)[^7] aims to help people use their careers to solve the world’s most pressing problems. To do this, they research how individuals can maximize the social impact of their careers, create online advice, and support readers who might enter priority areas.
+Fortunately, there is research available to help us make more informed choices. The organization [80,000 Hours](https://80000hours.org/)10 aims to help people use their careers to solve the world’s most pressing problems. To do this, they research how individuals can maximize the social impact of their careers, create online advice, and support readers who might enter priority areas.
 
 </details>
 
 <details>
 <summary>Cause impartiality and cause prioritization<span class="icon"></span></summary>
 
-[Cause impartiality](/utilitarianism-and-practical-ethics#cause-impartiality) is the view that one’s choice of social cause to focus on should depend on, and only on, the expected amount of good that one can do in that cause. Which causes will allow us to do the greatest amount of good by promoting well-being? Finding the answer to that question is called [cause prioritization](/acting-on-utilitarianism#cause-prioritization).
+[Cause impartiality](/utilitarianism-and-practical-ethics#cause-impartiality) is the view that one’s choice of social cause to focus on should depend on, and only on, the expected amount of good that one can do in that cause. Which causes will allow us to do the greatest amount of good by promoting wellbeing? Finding the answer to that question is called [cause prioritization](/acting-on-utilitarianism#cause-prioritization).
 
-We know that some ways of benefiting individuals do much more good than others. For example, within the cause of [global health and development](/acting-on-utilitarianism#global-health-and-development), some interventions are over 100 times as effective as others.[^8] Furthermore, many researchers believe that the difference in expected impact among _causes_ is as great as the differences among _interventions within a particular cause_. If so, focusing on the very best causes is vastly more impactful than focusing on average ones.
+We know that some ways of benefiting individuals do much more good than others. For example, within the cause of [global health and development](/acting-on-utilitarianism#global-health-and-development), some interventions are over 100 times as effective as others.11 Furthermore, many researchers believe that the difference in expected impact among _causes_ is as great as the differences among _interventions within a particular cause_. If so, focusing on the very best causes is vastly more impactful than focusing on average ones.
 
 </details>
 
 <details>
 <summary>Charitable giving<span class="icon"></span></summary>
 
-_→ Main article: [Charitable giving](/acting-on-utilitarianism#charitable-giving)_
+_→ Main article:_ [_Charitable giving_](/acting-on-utilitarianism#charitable-giving)
 
 In slogan form, the utilitarian recommendation for using your money to help others is to “give more and give better”. Giving more simply means increasing the proportion of your income you give to charity. Giving better means finding and donating to the organizations that make the best use of your donation.
 
-Citizens of affluent countries are in the richest few percent of the world’s population. By making small sacrifices, those in the affluent world have the power to dramatically improve the lives of others. Due to the extreme inequalities in wealth and income, one can do a lot more good by giving money to those most in need than by spending it on oneself.[^9]
+Citizens of affluent countries are in the richest few percent of the world’s population. By making small sacrifices, those in the affluent world have the power to dramatically improve the lives of others. Due to the extreme inequalities in wealth and income, one can do a lot more good by giving money to those most in need than by spending it on oneself.12
 
-To give better, one can follow the recommendations from organizations such as [GiveWell](https://www.givewell.org/), which conducts exceptionally in-depth charity evaluations. GiveWell’s best-guess estimate is that the most cost-effective charities working in global health can save a child’s life for about $3,000.[^10]
+To give better, one can follow the recommendations from organizations such as [GiveWell](https://www.givewell.org/), which conducts exceptionally in-depth charity evaluations. GiveWell’s best-guess estimate is that the most cost-effective charities working in global health can save a child’s life for about $3,000.13
 
 </details>
 
 <details>
 <summary>Classical utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Classical utilitarianism](/types-of-utilitarianism#the-two-elements-of-classical-utilitarianism)_
+_→ Main article:_ [_Classical utilitarianism_](/types-of-utilitarianism#the-two-elements-of-classical-utilitarianism)
 
-Classical utilitarianism is the view that one morally ought to promote just the sum total of happiness over suffering. Classical utilitarianism can be distinguished from the wider utilitarian family of views because it accepts _[hedonism](/theories-of-wellbeing#hedonism)_ as a theory of well-being and _[the total view](/population-ethics#the-total-view)_ of population ethics.
+Classical utilitarianism is the view that one morally ought to promote just the sum total of happiness over suffering. Classical utilitarianism can be distinguished from the wider utilitarian family of views because it accepts [_hedonism_](/theories-of-wellbeing#hedonism) as a theory of well-being and [_the total view_](/population-ethics#the-total-view) of population ethics.
 
 </details>
 
 <details>
 <summary>Consequentialism<span class="icon"></span></summary>
 
-_→ Main article: [Consequentialism](/types-of-utilitarianism#consequentialism)_
+_→ Main article:_ [_Consequentialism_](/types-of-utilitarianism#consequentialism)
 
-Consequentialism is the view that one morally ought to promote just good outcomes. On this view, bringing about good outcomes is all that ultimately matters, from a moral perspective. Thus, to evaluate whether to perform an action, we should look at its overall consequences, rather than any of its other features (such as the _type_ of action that it is). For instance, when breaking a promise has bad consequences—as it usually does—consequentialists oppose it. However, breaking a promise is not considered wrong in itself. In exceptional cases, breaking a promise could be the morally best action available, such as when it is necessary to save a life.
+Consequentialism is the view that the moral rightness of actions (or rules, policies, etc.) depends on, and only on, the value of their consequences. Thus, to evaluate whether an action is right or wrong, we should look at all its consequences rather than any of its other features. For instance, when breaking a promise has bad consequences—as it usually does—consequentialists consider it wrong to do so. However, breaking a promise is not considered wrong in and of itself. In exceptional cases breaking a promise would be morally permissible or even required, such as when doing so is necessary to save a life.
 
 Consequentialism is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
 
-External links: [Consequentialism](https://plato.stanford.edu/entries/consequentialism/), Stanford Encyclopedia of Philosophy
+_External links:_ [Consequentialism](https://plato.stanford.edu/entries/consequentialism/), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Cosmopolitanism<span class="icon"></span></summary>
 
-_→ Main article: [Cosmopolitanism](/utilitarianism-and-practical-ethics#cosmopolitanism)_
+_→ Main article:_ [_Cosmopolitanism_](/utilitarianism-and-practical-ethics#cosmopolitanism-expanding-the-moral-circle-across-geography)
 
 Moral cosmopolitanism is the view that if you have the means to save a life in a faraway country, doing so matters just as much as saving a life close by in your own country; all lives deserve equal moral consideration, wherever they are.
 
@@ -141,18 +141,18 @@ Utilitarianism accepts moral cosmopolitanism and consequently regards geographic
 
 An implication of accepting moral cosmopolitanism is to take [improving global health and development](/acting-on-utilitarianism#global-health-and-development) very seriously as moral priorities.
 
-External links: [Taxonomy of Contemporary Cosmopolitanisms](https://plato.stanford.edu/entries/cosmopolitanism/#TaxoContCosm), Stanford Encyclopedia of Philosophy
+_External links:_ [Taxonomy of Contemporary Cosmopolitanisms](https://plato.stanford.edu/entries/cosmopolitanism/#TaxoContCosm), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Demandingness<span class="icon"></span></summary>
 
-_→ Main article: [Demandingness](/utilitarianism-and-practical-ethics#demandingness)_
+_→ Main article:_ [_Demandingness_](/utilitarianism-and-practical-ethics#demandingness)
 
 Utilitarianism is a very demanding ethical theory: it maintains that any time you can do more to help other people than you can to help yourself, you should do so. For example, if you could sacrifice your life to save the lives of several other people then, other things being equal, according to utilitarianism, you ought to do so.
 
-Though occasions where sacrificing your own life is the best thing to do are rare, utilitarianism is still very demanding in the world today. For example, by[donating to a highly effective global health charity](/acting-on-utilitarianism#charitable-giving), you can save a child’s life for just a few thousand dollars.[^11] As long as such donations benefit others more than a few thousand dollars would benefit yourself—as they almost certainly do, if you are a typical citizen of an affluent country—you ought to donate. Indeed, you likely ought to donate the majority of your lifetime income.
+Though occasions where sacrificing your own life is the best thing to do are rare, utilitarianism is still very demanding in the world today. For example, by [donating to a highly effective global health charity](/acting-on-utilitarianism#charitable-giving), you can save a child’s life for just a few thousand dollars.14 As long as such donations benefit others more than a few thousand dollars would benefit yourself—as they almost certainly do, if you are a typical citizen of an affluent country—you ought to donate. Indeed, you likely ought to donate the majority of your lifetime income.
 
 As well as requiring very significant donations, utilitarianism claims that you ought to [choose whatever career will most benefit others](/acting-on-utilitarianism#career-choice), too. This might involve non-profit work, conducting important research, or going into politics or advocacy.
 
@@ -163,11 +163,11 @@ See also: [Demandingness Objection to Utilitarianism](/objections-to-utilitarian
 <details>
 <summary>Demandingness objection to utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Demandingness objection to utilitarianism](/objections-to-utilitarianism/demandingness)_
+_→ Main article:_ [_Demandingness objection to utilitarianism_](/objections-to-utilitarianism/demandingness)
 
 Many critics argue that utilitarianism is too demanding, because it requires us to always act such as to bring about the best outcome. The theory leaves no room for actions that are permissible yet do not bring about the best consequences; this is why some critics claim that utilitarianism is a morality only for saints.
 
-Consider that the money a person spends on dining out could pay for several bednets, each protecting two children in a low-income country from malaria for about two years.[^12] From a utilitarian perspective, the benefit to the person from dining out is much smaller than the benefit to the children from not having malaria, so it would seem the person has acted wrongly in choosing to have a meal out. Analogous reasoning applies to how we use our time: the hours someone spends on social media should apparently be spent volunteering for a charity, or working harder at one’s job to earn more money to donate.
+Consider that the money a person spends on dining out could pay for several bednets, each protecting two children in a low-income country from malaria for about two years.15 From a utilitarian perspective, the benefit to the person from dining out is much smaller than the benefit to the children from not having malaria, so it would seem the person has acted wrongly in choosing to have a meal out. Analogous reasoning applies to how we use our time: the hours someone spends on social media should apparently be spent volunteering for a charity, or working harder at one’s job to earn more money to donate.
 
 See the article [The Demandingness Objection](/objections-to-utilitarianism/demandingness) on how proponents of utilitarianism might respond to this objection.
 
@@ -176,31 +176,31 @@ See the article [The Demandingness Objection](/objections-to-utilitarianism/dema
 <details>
 <summary>Deontology<span class="icon"></span></summary>
 
-According to _deontology_, morality is about following a system of duties and rules, like “Do Not Lie” or “Do Not Steal”. As Larry Alexander and Michael Moore [write](https://plato.stanford.edu/entries/ethics-deontological/): “In contrast to consequentialist theories, deontological theories judge the morality of choices by criteria different from the states of affairs those choices bring about. The most familiar forms of deontology, and also the forms presenting the greatest contrast to consequentialism, hold that some choices cannot be justified by their effects—that no matter how morally good their consequences, some choices are morally forbidden”.[^13]
+According to _deontology_, morality is about following a system of duties and rules, like “Do Not Lie” or “Do Not Steal”. As Larry Alexander and Michael Moore [write](https://plato.stanford.edu/entries/ethics-deontological/): “In contrast to consequentialist theories, deontological theories judge the morality of choices by criteria different from the states of affairs those choices bring about. The most familiar forms of deontology, and also the forms presenting the greatest contrast to consequentialism, hold that some choices cannot be justified by their effects—that no matter how morally good their consequences, some choices are morally forbidden”.16
 
-The main alternatives to deontology are _[consequentialism](/types-of-utilitarianism#consequentialism)_, the view that the moral rightness of actions (or rules, policies, etc.) depends on, and only on, the value of their consequences, and _[virtue ethics](https://plato.stanford.edu/entries/ethics-virtue/)_, according to which morality is fundamentally about having or developing a virtuous character.
+The main alternatives to deontology are [_consequentialism_](/types-of-utilitarianism#consequentialism), the view that the moral rightness of actions (or rules, policies, etc.) depends on, and only on, the value of their consequences, and [_virtue ethics_](https://plato.stanford.edu/entries/ethics-virtue/), according to which morality is fundamentally about having or developing a virtuous character.
 
-External links: [Deontological Ethics](https://plato.stanford.edu/entries/ethics-deontological/), Stanford Encyclopedia of Philosophy
+_External links:_ [Deontological Ethics](https://plato.stanford.edu/entries/ethics-deontological/), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Desire theories of well-being<span class="icon"></span></summary>
 
-_→ Main article: [Desire theories of well-being](/theories-of-wellbeing#desire-theories)_
+_→ Main article:_ [_Theories of well-being: Desire theories_](/theories-of-wellbeing#desire-theories)
 
 According to desire theories only the satisfaction of desires or preferences matters for an individual’s well-being. The most well known desire theory is preference utilitarianism, the ethical theory on which you ought to promote just the sum total of preference satisfaction over dissatisfaction.
 
-The alternatives to desire theories include _[hedonism](/theories-of-wellbeing#hedonism)_, according to which the individual’s conscious experiences determines their well-being, and _[objective list theories](/theories-of-wellbeing#objective-list-theories)_, which propose a list of items that constitute well-being, such as conscious experiences, art, knowledge, love, friendship, and more.
+The alternatives to desire theories include [_hedonism_](/theories-of-wellbeing#hedonism), according to which the individual’s conscious experiences determines their well-being, and [_objective list theories_](/theories-of-wellbeing#objective-list-theories), which propose a list of items that constitute well-being, such as conscious experiences, art, knowledge, love, friendship, and more.
 
 </details>
 
 <details>
 <summary>Direct consequentialism & direct utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Consequentialism](/types-of-utilitarianism#consequentialism)_
+_→ Main article:_ [_Consequentialism_](/types-of-utilitarianism#consequentialism)
 
-According to direct consequentialism, the rightness of an action (or rule, policy, etc.) depends only on its consequences. On this view, to determine the right action in some set of feasible actions, we should directly evaluate the consequences of the actions to see which has the best consequences. The most well known direct consequentialist view is act utilitarianism, which assesses the moral rightness of actions, and only of actions, according to the sum total of well-being they produce.
+According to direct consequentialism, the rightness of an action (or rule, policy, etc.) depends only on its consequences. On this view, to determine the right action in some set of feasible actions, we should directly evaluate the consequences of the actions to see which has the best consequences. The most well known direct consequentialist view is act utilitarianism, which assesses the moral rightness of actions, and only of actions, according to the sum total of wellbeing they produce.
 
 The alternative to direct consequentialism is indirect consequentialism, according to which we should evaluate the moral status of an action (or rule, policy, etc.) _indirectly_, based on its relationship to something else (such as a rule), whose status is itself assessed in terms of its consequences.
 
@@ -209,9 +209,9 @@ The alternative to direct consequentialism is indirect consequentialism, accordi
 <details>
 <summary>Doctrine of Doing and Allowing<span class="icon"></span></summary>
 
-_→ Main article: [Doctrine of Doing and Allowing](/utilitarianism-and-practical-ethics#is-there-a-difference-between-doing-and-allowing-harm)_
+_→ Main article:_ [_Doctrine of Doing and Allowing_](/utilitarianism-and-practical-ethics#is-there-a-difference-between-doing-and-allowing-harm)
 
-Many non-consequentialists believe there is a morally relevant difference between [doing harm and allowing harm](https://plato.stanford.edu/entries/doing-allowing/), even if the consequences of an action or inaction are the same. This position is known as the “Doctrine of Doing and Allowing”, according to which harms caused by actions—by things we actively do—are worse than harms of omission.
+Many non-consequentialists believe there is a morally relevant difference between [_doing harm and allowing harm_](https://plato.stanford.edu/entries/doing-allowing/), even if the consequences of an action or inaction are the same. This position is known as the “Doctrine of Doing and Allowing”, according to which harms caused by actions—by things we actively do—are worse than harms of omission.
 
 However, while consequentialists—including utilitarians—accept that doing harm is typically instrumentally worse than allowing harm, they deny that doing harm is intrinsically worse than allowing harm. Thus, they reject the Doctrine of Doing and Allowing.
 
@@ -220,29 +220,29 @@ However, while consequentialists—including utilitarians—accept that doing ha
 <details>
 <summary>Effective altruism<span class="icon"></span></summary>
 
-_→ Main article: [Effective altruism](/acting-on-utilitarianism#effective-altruism)_
+_→ Main article:_ [_Effective altruism_](/acting-on-utilitarianism#effective-altruism)
 
-Those in the [effective altruism](https://www.effectivealtruism.org/) movement try to figure out, of all the different uses of our resources, which ones will do the most good, impartially considered, and act on that basis. So defined, effective altruism is both a research project—to figure out how to do the most good—and a practical project to implement the best guesses we have about how to do the most good.[^14]
+Those in the [effective altruism](https://www.effectivealtruism.org/) movement try to figure out, of all the different uses of our resources, which ones will do the most good, impartially considered, and act on that basis. So defined, effective altruism is both a research project—to figure out how to do the most good—and a practical project to implement the best guesses we have about how to do the most good.17
 
 </details>
 
 <details>
 <summary>Egalitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Egalitarianism](/near-utilitarian-alternatives#egalitarianism-and-distributive-justice)_
+_→ Main article:_ [_Egalitarianism and Distributive Justice_](/near-utilitarian-alternatives#egalitarianism-and-distributive-justice)
 
 Egalitarianism is the view that inequality is bad _in itself_, over and above any instrumental effects it may have on people's well-being.
 
 Egalitarians thus reject [welfarism](/types-of-utilitarianism#welfarism), the view that positive well-being is the only intrinsic good, and negative well-being is the only intrinsic bad.
 
-External links: [Egalitarianism](https://plato.stanford.edu/entries/egalitarianism/), Stanford Encyclopedia of Philosophy
+_External links:_ [Egalitarianism](https://plato.stanford.edu/entries/egalitarianism/), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Equal Consideration of Interests<span class="icon"></span></summary>
 
-_→ Main article: [Impartiality and the Equal Consideration of Interests](/types-of-utilitarianism#impartiality-and-the-equal-consideration-of-interests)_
+_→ Main article:_ [_Impartiality and the Equal Consideration of Interests_](/types-of-utilitarianism#impartiality-and-the-equal-consideration-of-interests)
 
 The _equal consideration of interests_ is a distinctively utilitarian conception of impartiality, according to which equal weight must be given to the interests of all individuals. This means treating well-being as equally valuable regardless of when, where, or to whom it occurs.
 
@@ -253,11 +253,11 @@ Alternative views include [prioritarianism](/near-utilitarian-alternatives#prior
 <details>
 <summary>Equality objection to utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Equality objection to utilitarianism](/objections-to-utilitarianism/equality)_
+_→ Main article:_ [_Equality objection to utilitarianism_](/objections-to-utilitarianism/equality)
 
-Some argue that utilitarianism conflicts with the ideal of equality. Suppose, for example, that you could choose between two possible distributions of well-being, _Equality_and \_Inequality_: Equality has 1,000 people at well-being level 45, while Inequality has 500 people at 80 well-being and another 500 people at 20 well-being.
+Some argue that utilitarianism conflicts with the ideal of equality. Suppose, for example, that you could choose between two possible distributions of wellbeing, _Equality_ and _Inequality_: Equality has 1,000 people at wellbeing level 45, while Inequality has 500 people at 80 wellbeing and another 500 people at 20 wellbeing.
 
-By the lights of utilitarianism, only the sum total of well-being determines the goodness of an outcome: it does not matter how that well-being is distributed across people. Since the sum total of well-being is greater in Inequality (= 50) than in Equality (= 45), the unequal outcome is preferable according to utilitarianism. Some philosophers object to the utilitarian view regarding this choice, claiming that the equal distribution of well-being in Equality provides a reason to choose this outcome. On this view, total well-being is not all that matters; equality of distribution also matters. Equality, it is claimed, is an important moral consideration that the utilitarian overlooks.
+By the lights of utilitarianism, only the sum total of wellbeing determines the goodness of an outcome: it does not matter how that wellbeing is distributed across people. Since the sum total of wellbeing is greater in Inequality (= 50) than in Equality (= 45), the unequal outcome is preferable according to utilitarianism. Some philosophers object to the utilitarian view regarding this choice, claiming that the equal distribution of wellbeing in Equality provides a reason to choose this outcome. On this view, total wellbeing is not all that matters; equality of distribution also matters. Equality, it is claimed, is an important moral consideration that the utilitarian overlooks.
 
 See the article [The Equality Objection](/objections-to-utilitarianism/equality) on how proponents of utilitarianism might respond to this objection.
 
@@ -266,42 +266,42 @@ See the article [The Equality Objection](/objections-to-utilitarianism/equality)
 <details>
 <summary>Existential risk reduction<span class="icon"></span></summary>
 
-_→ Main article: [Existential risk reduction](/acting-on-utilitarianism#existential-risk-reduction)_
+_→ Main article:_ [_Existential risk reduction_](/acting-on-utilitarianism#existential-risk-reduction)
 
-An existential risk is a risk that threatens the destruction of humanity’s long-term potential—such as all-out nuclear war, or extreme climate change, or an engineered global pandemic.[^15] From a utilitarian perspective (and the perspective of many other moral views), the realization of an existential risk would be uniquely bad and much worse than non-existential catastrophes. Besides the deaths of all 7.8 billion people on this planet, an existential catastrophe would irreversibly deprive humanity of a potentially grand future and preclude trillions of lives to come. Since the stakes involved with existential risks are so large, their mitigation may, therefore, be one of the most important moral issues we face.
+An existential risk is a risk that threatens the destruction of humanity’s long-term potential—such as all-out nuclear war, or extreme climate change, or an engineered global pandemic.18 From a utilitarian perspective (and the perspective of many other moral views), the realization of an existential risk would be uniquely bad and much worse than non-existential catastrophes. Besides the deaths of all 7.8 billion people on this planet, an existential catastrophe would irreversibly deprive humanity of a potentially grand future and preclude trillions of lives to come. Since the stakes involved with existential risks are so large, their mitigation may, therefore, be one of the most important moral issues we face.
 
-External links: [The Precipice: Existential Risk and the Future of Humanity](https://theprecipice.com/), Toby Ord (2020)
+_External links:_ [The Precipice: Existential Risk and the Future of Humanity](https://theprecipice.com/), Toby Ord (2020)
 
 </details>
 
 <details>
 <summary>Expanding moral circle<span class="icon"></span></summary>
 
-_→ Main article: [The expanding moral circle](/utilitarianism-and-practical-ethics#the-expanding-moral-circle)_
+_→ Main article:_ [_The expanding moral circle_](/utilitarianism-and-practical-ethics#the-expanding-moral-circle)
 
-We now recognize that characteristics like race, gender, and sexual orientation do not justify discriminating against individuals or disregarding their suffering. Over time, our society has gradually expanded our moral concern to ever more groups, a trend of moral progress often called the _expanding moral circle_.[^16] But what are the limits of this trend?
+We now recognize that characteristics like race, gender, and sexual orientation do not justify discriminating against individuals or disregarding their suffering. Over time, our society has gradually expanded our moral concern to ever more groups, a trend of moral progress often called the _expanding moral circle_.19 But what are the limits of this trend?
 
 Utilitarianism provides a clear response to this question: We should extend our moral concern to all _sentient beings_, meaning every individual capable of experiencing positive or negative conscious states. This includes humans and probably many non-human animals, but not plants or other entities that are non-sentient. This view is sometimes called _sentiocentrism_ as it regards sentience as the characteristic that entitles individuals to moral concern.
 
-A priority for utilitarians may be to help society to continue to widen its moral circle of concern.[^17] For instance, we may want to persuade people that they should help not just those in their own country, but also those on the other side of the world; not just those of their own species but all sentient creatures; and not just people currently alive but any people whose lives they can affect, including those in generations to come.
+A priority for utilitarians may be to help society to continue to widen its moral circle of concern. For instance, we may want to persuade people that they should help not just those in their own country, but also those on the other side of the world; not just those of their own species but all sentient creatures; and not just people currently alive but any people whose lives they can affect, including those in generations to come.
 
 </details>
 
 <details>
 <summary>Expectational utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Expectational utilitarianism](/types-of-utilitarianism#expectational-utilitarianism-versus-objective-utilitarianism)_
+_→ Main article:_ [_Expectational utilitarianism_](/types-of-utilitarianism#expectational-utilitarianism-versus-objective-utilitarianism)
 
-Expectational utilitarianism is the view we should promote _expected_ well-being, as opposed to the well-being an action will _in fact_ produce. Expectational utilitarianism states we should choose the actions with the highest expected value.[^18] The expected value of an action is the sum of the value of each of the potential outcomes multiplied by the probability of that outcome occurring. So, for example, according to expectational utilitarianism, we should choose a 10% chance of saving 1,000 lives over a 50% chance of saving 150 lives because the former option saves an expected 100 lives (= 10% \*1,000 lives) whereas the latter option saves an expected 75 lives (= 50%\* 150 lives).
+Expectational utilitarianism is the view we should promote _expected_ wellbeing, as opposed to the wellbeing an action will _in fact_ produce. Expectational utilitarianism states we should choose the actions with the highest expected value.20 The expected value of an action is the sum of the value of each of the potential outcomes multiplied by the probability of that outcome occurring. So, for example, according to expectational utilitarianism, we should choose a 10% chance of saving 1,000 lives over a 50% chance of saving 150 lives because the former option saves an expected 100 lives (= 10% \* 1,000 lives) whereas the latter option saves an expected 75 lives (= 50% \* 150 lives).
 
-The main alternative to expectational utilitarianism is _objective utilitarianism_, on which the rightness of an action depends on the well-being it will _in fact_ produce.
+The main alternative to expectational utilitarianism is _objective utilitarianism_, on which the rightness of an action depends on the wellbeing it will _in fact_ produce.
 
 </details>
 
 <details>
 <summary>Farm animal welfare<span class="icon"></span></summary>
 
-_→ Main article: [Farm animal welfare](/acting-on-utilitarianism#farm-animal-welfare)_
+_→ Main article:_ [_Farm animal welfare_](/acting-on-utilitarianism#farm-animal-welfare)
 
 Improving the welfare of farmed animals should be a high moral priority for utilitarians. The argument for this conclusion is simple: First, [animals matter morally](/utilitarianism-and-practical-ethics#speciesism); second, humans cause a huge amount of unnecessary suffering to animals in factory farms; third, there are easy ways to reduce the number of farmed animals and the severity of their suffering.
 
@@ -310,36 +310,36 @@ Improving the welfare of farmed animals should be a high moral priority for util
 <details>
 <summary>Global health and development<span class="icon"></span></summary>
 
-_→ Main article: [Global health and development](/acting-on-utilitarianism#global-health-and-development)_
+_→ Main article:_ [_Global health and development_](/acting-on-utilitarianism#global-health-and-development)
 
-Efforts in global health and development have a great track record of improving lives, making this cause appear especially tractable. Indeed, the best interventions in global health and development are incredibly cost-effective:[GiveWell](https://www.givewell.org/), a leading organization that conducts in-depth charity evaluations, estimates that top-rated charities can prevent the death of a child from malaria for just a few thousand dollars by providing preventive drugs.[^19] On this basis, global health and development may be considered a particularly high priority cause for utilitarians.[^20]
+Efforts in global health and development have a great track record of improving lives, making this cause appear especially tractable. Indeed, the best interventions in global health and development are incredibly cost-effective: [GiveWell](https://www.givewell.org/), a leading organization that conducts in-depth charity evaluations, estimates that top-rated charities can prevent the death of a child from malaria for just a few thousand dollars by providing preventive drugs.21 On this basis, global health and development may be considered a particularly high priority cause for utilitarians.22
 
 </details>
 
 <details>
 <summary>Global utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Global utilitarianism](/types-of-utilitarianism#global-utilitarianism-versus-hybrid-utilitarianism)_
+_→ Main article:_ [_Global utilitarianism_](/types-of-utilitarianism#global-utilitarianism-versus-hybrid-utilitarianism)
 
-Global utilitarianism is the view that the utilitarian standards of moral evaluation apply to anything of interest, including actions, motives, rules, virtues, policies, social institutions, etc.
+Global utilitarianism is the view that the utilitarian standards of right and wrong can evaluate anything of interest, including actions, motives, rules, virtues, policies, social institutions, etc.
 
-Global utilitarianism assesses the moral nature of, for example, a particular character trait, such as kindness or loyalty, based on the consequences that trait has for the well-being of others—just as act utilitarianism morally evaluates actions. Global utilitarianism's broad focus may help it to explain certain supposedly "non-consequentialist" intuitions.[^21] For instance, it captures the understanding that morality is not just about choosing the right acts but is also about following certain rules and developing a virtuous character.
+Global utilitarianism assesses the moral nature of, for example, a particular character trait, such as kindness or loyalty, based on the consequences that trait has for the wellbeing of others—just as act utilitarianism evaluates the rightness of actions. Global utilitarianism's broad focus may help it to explain certain supposedly "non-consequentialist" intuitions.23 For instance, it captures the understanding that morality is not just about choosing the right acts but is also about following certain rules and developing a virtuous character.
 
 </details>
 
 <details>
 <summary>Happiness and suffering<span class="icon"></span></summary>
 
-_→ Main article: [Theories of well-being: hedonism](/theories-of-wellbeing#hedonism)_
+_→ Main article:_ [_Theories of well-being: hedonism_](/theories-of-wellbeing#hedonism)
 
-Philosophers commonly use _happiness_ and _suffering_ as shorthand for the terms _positive conscious experience_ and _negative conscious experience_, respectively. According to ethical hedonists, happiness is the only thing good in and of itself and suffering is the only thing bad in and of itself. The hedonistic conception of happiness is broad: It covers not only paradigmatic instances of sensual pleasure—such as the experiences of eating delicious food or having sex—but also other positively valenced experiences, such as the experiences of solving a problem, reading a novel, or helping a friend.
+Philosophers commonly use _happiness_ and _suffering_ as shorthand for the terms _positive conscious experience_ and _negative conscious experience,_ respectively. According to ethical hedonists, happiness is the only thing good in and of itself and suffering is the only thing bad in and of itself. The hedonistic conception of happiness is broad: It covers not only paradigmatic instances of sensual pleasure—such as the experiences of eating delicious food or having sex—but also other positively valenced experiences, such as the experiences of solving a problem, reading a novel, or helping a friend.
 
 </details>
 
 <details>
 <summary>Harriet Taylor Mill<span class="icon"></span></summary>
 
-_→ Main article: [Harriet Taylor Mill](/utilitarian-thinker/harriet-taylor-mill)_
+_→ Main article:_ [_Harriet Taylor Mill_](/utilitarian-thinker/harriet-taylor-mill)
 
 Harriet Taylor Mill (1807 - 1858) was a British philosopher and women’s rights advocate. A close friend and later wife of John Stuart Mill, she had a profound impact on his thinking and worked in close collaboration with him. Despite her many contributions in books and magazines, most of her writing was only published under her own name after her death.
 
@@ -348,49 +348,49 @@ Harriet Taylor Mill (1807 - 1858) was a British philosopher and women’s rights
 <details>
 <summary>Hedonic calculus<span class="icon"></span></summary>
 
-[Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) proposed the hedonic calculus, or felicific calculus, as a method to determine the goodness and badness of an action’s consequences.[^22] Bentham suggested that in assessing these consequences, one should take into account their _intensity, duration, certainty, propinquity, fecundity_ (the chance that a pleasure is followed by other ones, a pain by further pains), _purity_ (the chance that pleasure is followed by pains and vice versa), and _extent_ (the number of persons affected). Applying the hedonic calculus to similarly assess all the alternative actions, would show which one has the best overall consequences, and should therefore be chosen.
+[Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) proposed the hedonic calculus, or felicific calculus, as a method to determine the goodness and badness of an action’s consequences.24 Bentham suggested that in assessing these consequences, one should take into account their _intensity, duration, certainty, propinquity, fecundity_ (the chance that a pleasure is followed by other ones, a pain by further pains)_, purity_ (the chance that pleasure is followed by pains and vice versa), and _extent_ (the number of persons affected). Applying the hedonic calculus to similarly assess all the alternative actions, would show which one has the best overall consequences, and should therefore be chosen.
 
-However, Bentham was realistic about the limitations of this method, writing that “it is not to be expected that this process [of calculating expected consequences] should be strictly pursued previously to every moral judgment”.[^23]
+However, Bentham was realistic about the limitations of this method, writing that “it is not to be expected that this process \[of calculating expected consequences\] should be strictly pursued previously to every moral judgment”.25
 
 </details>
 
 <details>
 <summary>Hedonism (theories of well-being)<span class="icon"></span></summary>
 
-_→ Main article: [Hedonism (theories of well-being)](/theories-of-wellbeing#hedonism)_
+_→ Main article:_ [_Theories of well-being: hedonism_](/theories-of-wellbeing#hedonism)
 
-Hedonism is the view that well-being consists in, and only in, the balance of positive over negative conscious experiences. For hedonism the only things good in and of themselves are the experiences of positive conscious states, such as enjoyment and pleasure; and the only things bad in and of themselves are the experiences of negative conscious states, such as misery and pain.
+Hedonism is the view that wellbeing consists in, and only in, the balance of positive over negative conscious experiences. For hedonism the only things good in and of themselves are the experiences of positive conscious states, such as enjoyment and pleasure; and the only things bad in and of themselves are the experiences of negative conscious states, such as misery and pain.
 
 The hedonistic conception of happiness is broad: It covers not only paradigmatic instances of sensual pleasure—such as the experiences of eating delicious food or having sex—but also other positively valenced experiences, such as the experiences of solving a problem, reading a novel, or helping a friend. Hedonists claim that all these experiences are _intrinsically_ valuable, which means they are valuable in and of themselves. Other goods, such as wealth, health, justice, fairness and equality are also valued by hedonists, but they are valued _instrumentally_. This means they are valued to the extent that they affect the conscious experience of individuals, rather than being valued in and of themselves.
 
-The two main alternatives to hedonism are _[desire theories](/theories-of-wellbeing#desire-theories)_, according to which only the satisfaction of desires or preferences matters for an individual’s well-being, and _[objective list theories](/theories-of-wellbeing#objective-list-theories)_, which propose a list of items that constitute well-being. This list can include conscious experiences or satisfied preferences, but it rarely stops there; ethicists commonly argue that the objective list includes art, knowledge, love, friendship, and more.
+The two main alternatives to hedonism are [_desire theories_](/theories-of-wellbeing#desire-theories), according to which only the satisfaction of desires or preferences matters for an individual’s wellbeing, and [_objective list theories_](/theories-of-wellbeing#objective-list-theories), which propose a list of items that constitute wellbeing. This list can include conscious experiences or satisfied preferences, but it rarely stops there; ethicists commonly argue that the objective list includes art, knowledge, love, friendship, and more.
 
 </details>
 
 <details>
 <summary>Henry Sidgwick<span class="icon"></span></summary>
 
-_→ Main article: [Henry Sidgwick](/utilitarian-thinker/henry-sidgwick)_
+_→ Main article:_ [_Henry Sidgwick_](/utilitarian-thinker/henry-sidgwick)
 
-Henry Sidgwick (1838 - 1900) was a British philosopher and economist. One of the classical utilitarians, he wrote one of the most important statements of utilitarianism in his [The Methods of Ethics](https://www.earlymoderntexts.com/assets/pdfs/sidgwick1874.pdf), which was said to be “the best book ever written on ethics”.[^24]
+Henry Sidgwick (1838 - 1900) was a British philosopher and economist. One of the classical utilitarians, he wrote one of the most important statements of utilitarianism in his [The Methods of Ethics](https://www.earlymoderntexts.com/assets/pdfs/sidgwick1874.pdf), which was said to be “the best book ever written on ethics”.26
 
 </details>
 
 <details>
-<summary>Hybrid Utilitarianism<span class="icon"></span></summary>
+<summary>Hybrid utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Global vs Hybrid Utilitarianism](/types-of-utilitarianism#global-utilitarianism-versus-hybrid-utilitarianism)_
+_→ Main article:_ [_Global vs Hybrid Utilitarianism_](/types-of-utilitarianism#global-utilitarianism-versus-hybrid-utilitarianism)
 
-Hybrid utilitarianism is the view that, while one morally ought to promote just overall well-being, the moral quality of an aim or intention can depend on factors other than whether it promotes overall well-being. In particular, hybrid utilitarians may understand virtue and praise-worthiness as concerning whether the target individual _intends_ good results, in contrast to global utilitarian evaluation of whether the target's intentions \_produce_good results. When the two come into conflict, we should prefer to achieve good results than to merely intend them—so in this sense the hybrid utilitarian agrees with much that the global utilitarian wants to say. Hybridists just hold that there is more to say in addition.
+Hybrid utilitarianism is the view that, while one morally ought to promote just overall well-being, the moral quality of an aim or intention can depend on factors other than whether it promotes overall well-being. In particular, hybrid utilitarians may understand virtue and praise-worthiness as concerning whether the target individual _intends_ good results, in contrast to global utilitarian evaluation of whether the target's intentions _produce_ good results. When the two come into conflict, we should prefer to achieve good results than to merely intend them—so in this sense the hybrid utilitarian agrees with much that the global utilitarian wants to say. Hybridists just hold that there is more to say in addition.
 
 </details>
 
 <details>
 <summary>Impartiality<span class="icon"></span></summary>
 
-_→ Main article: [Impartiality](/types-of-utilitarianism#impartiality-and-the-equal-consideration-of-interests)_
+_→ Main article:_ [_Impartiality_](/types-of-utilitarianism#impartiality)
 
-Impartiality is the view that the identity of individuals is irrelevant to the value of an outcome. Utilitarians accept a conception of impartiality that further entails the _equal consideration of interests_: that is, the claim that equal weight must be given to the interests of all individuals. This means treating well-being as equally valuable regardless of when, where, or to whom it occurs. As a consequence, utilitarianism values the well-being of all individuals equally, regardless of their nationality, gender, [where](/utilitarianism-and-practical-ethics#cosmopolitanism) or [when they live](/utilitarianism-and-practical-ethics#longtermism), or even [their species](/utilitarianism-and-practical-ethics#speciesism).
+Impartiality is the view that the identity of individuals is irrelevant to the value of an outcome. Utilitarians accept a conception of impartiality that further entails the _equal consideration of interests_: that is, the claim that equal weight must be given to the interests of all individuals. This means treating wellbeing as equally valuable regardless of when, where, or to whom it occurs. As a consequence, utilitarianism values the wellbeing of all individuals equally, regardless of their nationality, gender, [where](/utilitarianism-and-practical-ethics#cosmopolitanism) or [when they live](/utilitarianism-and-practical-ethics#longtermism), or even [their species](/utilitarianism-and-practical-ethics#speciesism).
 
 Impartiality is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
 
@@ -399,7 +399,7 @@ Impartiality is one of the [four elements of utilitarian ethical theories](/type
 <details>
 <summary>Indirect consequentialism & indirect utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Consequentialism](/types-of-utilitarianism#consequentialism)_
+_→ Main article:_ [_Consequentialism_](/types-of-utilitarianism#consequentialism)
 
 According to indirect consequentialism we should evaluate the moral status of an action _indirectly_, based on its relationship to something else (such as a rule), whose status is itself assessed in terms of its consequences. The most well known indirect consequentialist view is rule utilitarianism, which holds that what makes an action right is that it conforms to the set of rules that would have the best utilitarian consequences if they were generally accepted or followed.
 
@@ -410,14 +410,14 @@ The main alternative to indirect consequentialism is direct consequentialism, ac
 <details>
 <summary>Infinite ethics<span class="icon"></span></summary>
 
-[In a 2011 paper](https://www.nickbostrom.com/ethics/infinite.html), Nick Bostrom suggests that infinities in ethics may present a problem for aggregative consequentialist theories, including utilitarianism. Bostrom describes this problem as follows: “Modern cosmology teaches that the world might well contain an infinite number of happy and sad people and other candidate value-bearing locations. Aggregative ethics implies that such a world contains an infinite amount of positive value and an infinite amount of negative value. You can affect only a finite amount of good or bad. In standard cardinal arithmetic, an infinite quantity is unchanged by the addition or subtraction of any finite quantity. So it appears you cannot change the value of the world”.[^25]
+[In a 2011 paper](https://www.nickbostrom.com/ethics/infinite.html), Nick Bostrom suggests that infinities in ethics may present a problem for aggregative consequentialist theories, including utilitarianism. Bostrom describes this problem as follows: “Modern cosmology teaches that the world might well contain an infinite number of happy and sad people and other candidate value-bearing locations. Aggregative ethics implies that such a world contains an infinite amount of positive value and an infinite amount of negative value. You can affect only a finite amount of good or bad. In standard cardinal arithmetic, an infinite quantity is unchanged by the addition or subtraction of any finite quantity. So it appears you cannot change the value of the world”.27
 
 </details>
 
 <details>
 <summary>Jeremy Bentham<span class="icon"></span></summary>
 
-_→ Main article: [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham)_
+_→ Main article:_ [_Jeremy Bentham_](/utilitarian-thinker/jeremy-bentham)
 
 Jeremy Bentham (1748 - 1832) was a British philosopher and social reformer, who is widely regarded as the founder of classical utilitarianism. His most influential work is [An Introduction to the Principles of Morals and Legislation](https://www.earlymoderntexts.com/assets/pdfs/bentham1780.pdf) (1789).
 
@@ -426,45 +426,45 @@ Jeremy Bentham (1748 - 1832) was a British philosopher and social reformer, who 
 <details>
 <summary>John Stuart Mill<span class="icon"></span></summary>
 
-_→ Main article: [John Stuart Mill](/utilitarian-thinker/john-stuart-mill)_
+_→ Main article:_ [_John Stuart Mill_](/utilitarian-thinker/john-stuart-mill)
 
-John Stuart Mill (1806 - 1873) was a British philosopher and political economist. A student of Jeremy Bentham, Mill promoted the ideas of utilitarianism and liberalism and has been called “the most influential English language philosopher of the nineteenth century”. His most influential works include his books [Utilitarianism](https://www.earlymoderntexts.com/assets/pdfs/mill1863.pdf) (1863) and [On Liberty](https://socialsciences.mcmaster.ca/econ/ugcm/3ll3/mill/liberty.pdf) (1859).
+John Stuart Mill (1806 - 1873) was a British philosopher and political economist. A student of Jeremy Bentham, Mill promoted the ideas of utilitarianism and liberalism and has been called “the most influential English language philosopher of the nineteenth century”. His most influential works include his books [Utilitarianism](/books/utilitarianism-john-stuart-mill/1) (1863) and [On Liberty](/books/on-liberty-john-stuart-mill/1) (1859).
 
 </details>
 
 <details>
 <summary>Longtermism<span class="icon"></span></summary>
 
-_→ Main article: [Longtermism](/utilitarianism-and-practical-ethics#longtermism)_
+_→ Main article:_ [_Longtermism_](/utilitarianism-and-practical-ethics#longtermism)
 
-Strong longtermism is the view that the most important determinant of the value of our actions today is how those actions affect the very long-run future. Strong longtermism is implied by most plausible forms of utilitarianism[^26] if we assume that some of our actions can meaningfully affect the long-term future and that we can estimate which effects are positive and which negative. A key reason why most utilitarians would endorse strong longtermism is that they accept _temporal [impartiality](/types-of-utilitarianism#impartiality-and-the-equal-consideration-of-interests)_, the view that the well-being of future generations is no less important simply because they are far away in time than the well-being of those alive today.
+Strong longtermism is the view that the most important determinant of the value of our actions today is how those actions affect the very long-run future. Strong longtermism is implied by most plausible forms of utilitarianism28 if we assume that some of our actions can meaningfully affect the long-term future and that we can estimate which effects are positive and which negative. A key reason why most utilitarians would endorse strong longtermism is that they accept _temporal_ [_impartiality_](/types-of-utilitarianism#impartiality), the view that the wellbeing of future generations is no less important simply because they are far away in time than the wellbeing of those alive today.
 
 An implication of strong longtermism is to take [existential risk reduction](/acting-on-utilitarianism#existential-risk-reduction) very seriously as a moral priority.
 
-External links:
+_External links:_
 
 - Greaves, H. & MacAskill, W. (2019). [The case for strong longtermism](https://globalprioritiesinstitute.org/hilary-greaves-william-macaskill-the-case-for-strong-longtermism/). _Global Priorities Institute Working Paper_, 7.
-- Beckstead, N. (2013). [On the Overwhelming Importance of Shaping the Far-Future](https://drive.google.com/open?id=0B4kMPIEI5Mb8Q0tOUTA1M0hBcGM). Ph.D. Dissertation, Rutgers University.
+- Beckstead, N. (2013). [_On the Overwhelming Importance of Shaping the Far-Future_](https://drive.google.com/open?id=0B4kMPIEI5Mb8Q0tOUTA1M0hBcGM). Ph.D. Dissertation, Rutgers University.
 
 </details>
 
 <details>
 <summary>Maximizing utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Scalar versus maximizing or satisficing utilitarianism](/types-of-utilitarianism#reconstructing-rightness-maximizing-satisficing-and-scalar-utilitarianism)_
+_→ Main article:_ [_Scalar versus maximizing or satisficing utilitarianism_](/types-of-utilitarianism#scalar-versus-maximizing-or-satisficing-utilitarianism)
 
-Maximizing utilitarianism is the view that within any set of options, the action that produces the most well-being is right, and all other actions are wrong.
+Maximizing utilitarianism is the view that within any set of options, the action that produces the most wellbeing is right, and all other actions are wrong.
 
 Though this is the most common statement of utilitarianism, it may be misleading in some respects. Utilitarians agree that you _ideally_ ought to choose whatever action would best promote overall well-being. That's what you have the _most_ moral reason to do. But they do not recommend blaming you every time you fall short of this ideal. As a result, many utilitarians consider it misleading to take their claims about what ideally ought to be done as providing an account of moral "rightness" or "obligation" in the ordinary sense.
 
-The main alternatives to maximizing utilitarianism include _scalar utilitarianism_, according to which rightness and wrongness are matters of degree[^27], and _satisficing utilitarianism_, which holds that within any set of options, an action is right if it produces _enough_ well-being.[^28]
+The main alternatives to maximizing utilitarianism include _scalar utilitarianism_, according to which rightness and wrongness are matters of degree29, and _satisficing utilitarianism_, which holds that within any set of options, an action is right if it produces _enough_ wellbeing.30
 
 </details>
 
 <details>
 <summary>Mozi<span class="icon"></span></summary>
 
-_→ Main article: [Mozi](/utilitarian-thinker/mozi)_
+_→ Main article:_ [_Mozi_](/utilitarian-thinker/mozi)
 
 Mò Dí (墨翟), better known as Mòzǐ or “Master Mò,” flourished c. 430 BCE. in what is now Tengzhou, Shandong Province, China. Likely an artisan by craft, Mò Dí attracted many dedicated followers and founded the philosophical school of Mohism during China’s Warring States Period (475 - 221 BCE)—an early predecessor to utilitarianism.
 
@@ -473,9 +473,9 @@ Mò Dí (墨翟), better known as Mòzǐ or “Master Mò,” flourished c. 430 
 <details>
 <summary>Multi-level utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Multi-level utilitarianism versus single-level utilitarianism](/types-of-utilitarianism#multi-level-utilitarianism-versus-single-level-utilitarianism)_
+_→ Main article:_ [_Multi-level utilitarianism versus single-level utilitarianism_](/types-of-utilitarianism#multi-level-utilitarianism-versus-single-level-utilitarianism)
 
-Multi-level utilitarianism is the view that individuals should usually follow tried-and-tested rules of thumb, or _heuristics_, rather than trying to calculate which action will produce the most well-being. According to multi-level utilitarianism, following, under most circumstances, a set of simple moral heuristics—do not lie, steal, kill, etc.—will lead to the best outcomes overall. Often, we should use the commonsense moral norms and laws of our society as rules of thumb to guide our actions. Following these norms and laws usually leads to good outcomes because they are based on society’s experience of what promotes individual well-being.
+Multi-level utilitarianism is the view that individuals should usually follow tried-and-tested rules of thumb, or _heuristics_, rather than trying to calculate which action will produce the most wellbeing. According to multi-level utilitarianism, following, under most circumstances, a set of simple moral heuristics—do not lie, steal, kill, etc.—will lead to the best outcomes overall. Often, we should use the commonsense moral norms and laws of our society as rules of thumb to guide our actions. Following these norms and laws usually leads to good outcomes because they are based on society’s experience of what promotes individual wellbeing.
 
 Thus, multi-level utilitarianism understands utilitarianism as a _criterion of rightness_, not as a _decision procedure_. A criterion of rightness tells us what it takes for an action (or rule, policy, etc.) to be right or wrong. A decision procedure is something that we use when thinking about what to do.
 
@@ -486,9 +486,9 @@ The main alternative to multi-level utilitarianism is _single-level utilitariani
 <details>
 <summary>Negative utilitarianism<span class="icon"></span></summary>
 
-Negative utilitarianism is a version of utilitarianism that assigns either no (at its most extreme) or considerably less (in its moderate form) value to the promotion of happiness relative to the reduction of suffering. One of the earliest academic formulations and critiques of negative utilitarianism was made by R. N. Smart in response to Karl Popper.[^29]
+Negative utilitarianism is a version of utilitarianism that assigns either no (at its most extreme) or considerably less (in its moderate form) value to the promotion of happiness relative to the reduction of suffering. One of the earliest academic formulations and critiques of negative utilitarianism was made by R. N. Smart in response to Karl Popper.31
 
-External links:
+_External links:_
 
 - Smart, J.J.C. (1989). [Negative Utilitarianism](https://doi.org/10.1007/978-94-009-2380-5_3), in D’Agostino F., Jarvie I.C. (eds) _Freedom and Rationality. Boston Studies in the Philosophy of Science_. 117. Springer, Dordrecht.
 - Walker, A. D. M. (1974). [Negative Utilitarianism](http://www.jstor.org/stable/2252744). _Mind_, New Series. 83(331): 424–28.
@@ -499,27 +499,27 @@ External links:
 <details>
 <summary>Objective list theories of well-being<span class="icon"></span></summary>
 
-_→ Main article: [Objective list theories of well-being](/theories-of-wellbeing#objective-list-theories)_
+_→ Main article:_ [_Objective list theories of well-being_](/theories-of-wellbeing#objective-list-theories)
 
-Objective list theories propose a list of items that constitute well-being. This list can include conscious experiences or satisfied preferences, but it rarely stops there; ethicists commonly argue that the objective list includes art, knowledge, love, friendship, and more.
+Objective list theories propose a list of items that constitute wellbeing. This list can include conscious experiences or satisfied preferences, but it rarely stops there; ethicists commonly argue that the objective list includes art, knowledge, love, friendship, and more.
 
-The main alternatives to objective list theories include _[hedonism](/theories-of-wellbeing#hedonism)_, the view that well-being consists in, and only in, the balance of positive over negative conscious experiences, and _[desire theories](/theories-of-wellbeing#desire-theories)_, according to which only the satisfaction of desires or preferences matters for an individual’s well-being.
+The main alternatives to objective list theories include [_hedonism_](/theories-of-wellbeing#hedonism), the view that wellbeing consists in, and only in, the balance of positive over negative conscious experiences, and [_desire theories_](/theories-of-wellbeing#desire-theories), according to which only the satisfaction of desires or preferences matters for an individual’s wellbeing.
 
 </details>
 
 <details>
 <summary>Objective utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Expectation utilitarianism versus objective utilitarianism](/types-of-utilitarianism#expectational-utilitarianism-versus-objective-utilitarianism)_
+_→ Main article:_ [_Expectation utilitarianism versus objective utilitarianism_](/types-of-utilitarianism#expectational-utilitarianism-versus-objective-utilitarianism)
 
-Objective utilitarianism is the view that the rightness of an action depends on the well-being it will _in fact_ produce, as opposed to the view we should promote \_expected_well-being (i.e. expectational utilitarianism).
+Objective utilitarianism is the view that the rightness of an action depends on the wellbeing it will _in fact_ produce, as opposed to the view we should promote _expected_ wellbeing (i.e. expectational utilitarianism).
 
 </details>
 
 <details>
 <summary>Outreach<span class="icon"></span></summary>
 
-_→ Main article: [Outreach](/acting-on-utilitarianism#outreach)_
+_→ Main article:_ [_Outreach_](/acting-on-utilitarianism#outreach)
 
 An effective way of doing good is by inspiring others to try to do more good. Thus, the best course of action for many people may be to develop and promote positive ideas and values, such as those associated with utilitarianism, and be a positive role-model in one’s behavior. By raising awareness of positive ideas and values, it is plausible that you could inspire several people to follow their recommendations. In this way, you will achieve a multiplier effect on your social impact—the people you inspire will do several times as much good as you would have achieved by working directly to solve the most important moral problems. Because many positive ideas and values, including utilitarianism, are still little-known and little understood, there may be a lot of value in promoting them.
 
@@ -528,34 +528,34 @@ An effective way of doing good is by inspiring others to try to do more good. Th
 <details>
 <summary>Peter Singer<span class="icon"></span></summary>
 
-_→ Main article: [Peter Singer](/utilitarian-thinker/peter-singer)_
+_→ Main article:_ [_Peter Singer_](/utilitarian-thinker/peter-singer)
 
-Peter Singer (1946) is an Australian moral philosopher and Professor of Bioethics at Princeton University. His work concentrates on issues in applied ethics, in particular our treatment of animals, the ethics of global poverty, and effective altruism. The publication of his 1975 book [Animal Liberation](<https://en.wikipedia.org/wiki/Animal_Liberation_(book)>) helped start the modern animal rights movement.
+Peter Singer (1946) is an Australian moral philosopher and Professor of Bioethics at Princeton University. His work concentrates on issues in applied ethics, in particular our treatment of animals, the ethics of global poverty, and effective altruism. The publication of his 1975 book [Animal Liberation](https://en.wikipedia.org/wiki/Animal_Liberation_(book)) helped start the modern animal rights movement.
 
 </details>
 
 <details>
 <summary>Population ethics<span class="icon"></span></summary>
 
-_→ Main article: [Population ethics](/population-ethics)_
+_→ Main article:_ [_Population ethics_](/population-ethics)
 
-Population ethics deals with the ethical problems that arise when our actions affect who and how many people are born and at what quality of life.
+Population ethics deals with the moral problems that arise when our actions affect who and how many people are born and at what quality of life.
 
-Some of the main theories of population ethics include the _[total view](/population-ethics#the-total-view)_, the _[average view](/population-ethics#the-average-view)_, and _[person-affecting views](/population-ethics#person-affecting-views-and-the-procreative-asymmetry)_. According to the total view, one outcome is better than another if and only if it contains greater total well-being, even if that is in virtue of simply having more people. Similarly, according to the average view, one outcome is better than another if and only if it contains greater average well-being. Person-affecting views are a family of views that share the intuition that an act can only be good/bad if it is good/bad _for_ someone. Standard person-affecting views stand in opposition to the total view since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
+Some of the main theories of population ethics include the [_total view_](/population-ethics#the-total-view), the [_average view_](/population-ethics#the-average-view), and [_person-affecting views_](/population-ethics#person-affecting-views-and-the-procreative-asymmetry). According to the total view, one outcome is better than another if and only if it contains greater total wellbeing, even if that is in virtue of simply having more people. Similarly, according to the average view, one outcome is better than another if and only if it contains greater average wellbeing. Person-affecting views are a family of views that share the intuition that an act can only be good/bad if it is good/bad _for_ someone. Standard person-affecting views stand in opposition to the total view since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
 
-External links:
+_External links:_
 
-- Greaves, H. (2017). [Population Axiology](https://doi.org/10.1111/phc3.12442). _Philosophy Compass_. 12.
-- [The Repugnant Conclusion](https://plato.stanford.edu/archives/spr2017/entries/repugnant-conclusion/). The Stanford Encyclopedia of Philosophy.
+* Greaves, H. (2017). [Population Axiology](https://doi.org/10.1111/phc3.12442). _Philosophy Compass_. 12.
+* [The Repugnant Conclusion](https://plato.stanford.edu/archives/spr2017/entries/repugnant-conclusion/). The Stanford Encyclopedia of Philosophy.
 
 </details>
 
 <details>
 <summary>Preference utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Theories of well-being](/theories-of-wellbeing)_
+_→ Main article:_ [_Theories of well-being_](/theories-of-wellbeing)
 
-Preference utilitarianism is the ethical theory on which one ought to promote just the sum total of preference satisfaction over dissatisfaction. In addition to the [four elements](/types-of-utilitarianism#the-four-elements-of-utilitarianism) shared by all utilitarian ethical theories, preference utilitarianism accepts a [desire theory](/theories-of-wellbeing#desire-theories) of well-being, according to which only the satisfaction of desires or preferences matters for an individual’s well-being.
+Preference utilitarianism is the ethical theory on which one ought to promote just the sum total of preference satisfaction over dissatisfaction. In addition to the [four elements](/types-of-utilitarianism#the-four-elements-of-utilitarianism) shared by all utilitarian ethical theories, preference utilitarianism accepts a [desire theory of well-being](/theories-of-wellbeing#desire-theories), according to which only the satisfaction of desires or preferences matters for an individual’s well-being.
 
 Other utilitarians may accept a different theory of well-being, such as hedonism or objective list theory.
 
@@ -564,23 +564,25 @@ Other utilitarians may accept a different theory of well-being, such as hedonism
 <details>
 <summary>Principle of utility<span class="icon"></span></summary>
 
-In his main work _An Introduction to the Principles of Morals and Legislation_, [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) calls the core idea at the heart of his utilitarian philosophy the _principle of utility_. He describes it as follows: “By the ‘principle of utility’ is meant the principle that approves or disapproves of every action according to the tendency it appears to have to increase or lessen—i.e. to promote or oppose—the happiness of the person or group whose interest is in question”.[^30]
+In his main work _An Introduction to the Principles of Morals and Legislation_, [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham) calls the core idea at the heart of his utilitarian philosophy the _principle of utility_. He describes it as follows: “By the ‘principle of utility’ is meant the principle that approves or disapproves of every action according to the tendency it appears to have to increase or lessen—i.e. to promote or oppose—the happiness of the person or group whose interest is in question”.32
 
 </details>
 
 <details>
 <summary>Prioritarianism<span class="icon"></span></summary>
 
-_→ Main article: [Prioritarianism](/near-utilitarian-alternatives#prioritarianism)_
+_→ Main article:_ [_Prioritarianism_](/near-utilitarian-alternatives#prioritarianism)
 
-Prioritarianism holds that "benefiting people matters more the worse off these people are."[^31] Prioritarians thus reject the utilitarian conception of impartiality that assigns equal weight to everyone's interests (no matter their current level of well-being.)
+Prioritarianism holds that "benefiting people matters more the worse off these people are."\[\*\] Prioritarians thus reject the utilitarian conception of impartiality that assigns equal weight to everyone's interests (no matter their current level of well-being.)
 
-External links: [Priority](https://plato.stanford.edu/entries/egalitarianism/#Pri), Stanford Encyclopedia of Philosophy
+\[\*\]: Parfit, D. (1997). Equality and Priority. _Ratio_ 10(3): 202–221, p. 213.
+
+_External links:_ [Priority](https://plato.stanford.edu/entries/egalitarianism/#Pri), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
-<summary>Quality-adjusted life year (QALY)<span class="icon"></span></summary>
+<summary>Quality-Adjust Life Years (QALYs)<span class="icon"></span></summary>
 
 The quality-adjusted life year (QALY) is a measure of the value of health outcomes, taking into account both _quantity_ and _quality_ of life.
 
@@ -588,11 +590,11 @@ When medical resources are scarce, utilitarians (amongst others) will want the r
 
 But _quantity_ of life is not the only thing that's relevant: we also care about _quality_ of life. Health economists thus devised the _quality-adjusted life-year_ metric, based on survey data of how most people would weigh trade-offs between different medical conditions and extra years of life. For example, if most people would require at least ten years of life while clinically depressed in order to outweigh the value of one year of life in full health, that suggests they value one life-year of clinical depression as roughly equal to 0.1 QALYs. If given a choice between successfully treating clinical depression for 20 years (i.e., 0.9 \* 20 = 18 QALY gain), or extending someone else's life by 10 years in full health (i.e. 10 QALY gain), these made-up numbers would suggest that the depression treatment was more important.
 
-External links:
+_External links:_
 
-- Sassi, F. (2006) [Calculating QALYs, comparing QALY and DALY calculations](https://doi.org/10.1093/heapol/czl018)._Health Policy Plan_, 21(5): 402–8.
-- Singer, P., McKie, J., Kuhse, H., & Richardson, J. (1995). [Double jeopardy and the use of QALYs in health care allocation](http://dx.doi.org/10.1136/jme.21.3.144). _Journal of Medical Ethics_, 21(3): 144–150.
-- Chappell, R.Y. (2016). [Against ‘Saving Lives’: Equal Concern and Differential Impact](https://dx.doi.org/10.1111/bioe.12171). _Bioethics_, 30(3): 159–164. (Note that Chappell is a co-author of this website)
+Sassi, F. (2006) [Calculating QALYs, comparing QALY and DALY calculations](https://doi.org/10.1093/heapol/czl018). _Health Policy Plan_, 21(5): 402–8.  
+Singer, P., McKie, J., Kuhse, H., & Richardson, J. (1995). [Double jeopardy and the use of QALYs in health care allocation](http://dx.doi.org/10.1136/jme.21.3.144). _Journal of Medical Ethics_, 21(3): 144–150.  
+Chappell, R.Y. (2016). [Against ‘Saving Lives’: Equal Concern and Differential Impact](https://dx.doi.org/10.1111/bioe.12171). _Bioethics_, 30(3): 159–164. (Note that Chappell is a co-author of this website)
 
 </details>
 
@@ -602,15 +604,14 @@ External links:
 _→ Main article: [Richard M. Hare](/utilitarian-thinker/richard-hare)_
 
 Richard M. Hare (1919 - 2002) was a British philosopher and Professor at the Universities of Oxford and Florida. One of the most influential moral philosophers of the twentieth century, Hare is most famous for his meta-ethical theory of [prescriptivism](https://plato.stanford.edu/entries/moral-cognitivism/#PreUniPre), which he used to argue for utilitarianism.
-
 </details>
 
 <details>
 <summary>Rights objection to utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Rights objection to utilitarianism](/objections-to-utilitarianism/rights)_
+_→ Main article:_ [_Rights objection to utilitarianism_](/objections-to-utilitarianism/rights)
 
-According to commonsense morality and many non-utilitarian theories, there are certain \_moral constraints_you should never, or rarely, violate. These constraints are expressed in moral rules like “do not lie!” and “do not kill!”. These rules are intuitively very plausible. This presents a problem for utilitarianism. The reason for this is that utilitarianism not only specifies which outcomes are best⁠—those having the highest overall level of well-being⁠—but also says that it would be wrong to fail to realize these outcomes.
+According to commonsense morality and many non-utilitarian theories, there are certain _moral constraints_ you should never, or rarely, violate. These constraints are expressed in moral rules like “do not lie!” and “do not kill!”. These rules are intuitively very plausible. This presents a problem for utilitarianism. The reason for this is that utilitarianism not only specifies which outcomes are best⁠—those having the highest overall level of wellbeing⁠—but also says that it would be wrong to fail to realize these outcomes.
 
 Sometimes, realizing the best outcome may require violating moral constraints⁠ against harming others⁠—that is, violating their rights. For example, suppose there were five people waiting for an organ transplant and that you could save their lives if you killed one other person to harvest their organs. Intuitively, we would regard this as wrong, but it seems that utilitarianism would regard this as morally required.
 
@@ -625,22 +626,22 @@ Rule utilitarianism is the view that what makes an action right is that it confo
 
 The main alternative to rule utilitarianism is _act utilitarianism_, a direct consequentialist view, which directly assesses the moral rightness of (and only of) actions by looking at their consequences.
 
-External links: [Rule consequentialism](https://plato.stanford.edu/entries/consequentialism-rule/), Stanford Encyclopedia of Philosophy
+_External links:_ [Rule consequentialism](https://plato.stanford.edu/entries/consequentialism-rule/), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Satisficing utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Scalar versus maximizing or satisficing utilitarianism](/types-of-utilitarianism#reconstructing-rightness-maximizing-satisficing-and-scalar-utilitarianism)_
+_→ Main article:_ [_Scalar versus maximizing or satisficing utilitarianism_](/types-of-utilitarianism#reconstructing-rightness-maximizing-satisficing-and-scalar-utilitarianism)
 
-Satisficing utilitarianism is the view that within any set of options, an action is right if it produces _enough_ well-being.
+Satisficing utilitarianism is the view that within any set of options, an action is right if it produces _enough_ wellbeing.
 
 However, this proposal has some problems and has not found wide support. To see this, suppose that Sophie could save no one, or save 999 people at great personal sacrifice, or save 1,000 people at even greater personal sacrifice. From the utilitarian’s perspective, we still want to say there is reason to save the 1,000 people over the 999 people; labeling both actions as _right_ would risk ignoring the important moral difference between these two options.
 
-The main alternatives to satisficing utilitarianism are _scalar utilitarianism_, according to which rightness and wrongness are matters of degree[^32], and _maximizing utilitarianism_, the view that within any set of options, the action that produces the most well-being is right, and all other actions are wrong.
+The main alternatives to satisficing utilitarianism are _scalar utilitarianism_, according to which rightness and wrongness are matters of degree33, and _maximizing utilitarianism_, the view that within any set of options, the action that produces the most wellbeing is right, and all other actions are wrong.
 
-External links:
+_External links:_
 
 - Bradley, B. (2006). [Against Satisficing Consequentialism](https://doi.org/10.1017/S0953820806001877). _Utilitas_, 18(2): 97–108.
 - Chappell, R.Y. (2019). [Willpower Satisficing](https://dx.doi.org/10.1111/nous.12213). _Noûs_ 53 (2): 251–265. Note that Chappell is a co-author of this website.
@@ -651,13 +652,13 @@ External links:
 <details>
 <summary>Scalar utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Scalar versus maximizing or satisficing utilitarianism](/types-of-utilitarianism#reconstructing-rightness-maximizing-satisficing-and-scalar-utilitarianism)_
+_→ Main article:_ [_Scalar versus maximizing or satisficing utilitarianism_](/types-of-utilitarianism#scalar-versus-maximizing-or-satisficing-utilitarianism)
 
-Scalar utilitarianism is the view that moral evaluation is a matter of degree: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.[^33] On this view, there is no fundamental, sharp distinction between 'right' and 'wrong' actions, just a continuous scale from morally better to worse.
+Scalar utilitarianism is the view that moral evaluation is a matter of degree: the more that an act would promote the sum total of well-being, the more moral reason one has to perform that act.34 On this view, there is no fundamental, sharp distinction between 'right' and 'wrong' actions, just a continuous scale from morally better to worse.
 
-The main alternatives to scalar utilitarianism are _maximizing utilitarianism_, the view that within any set of options, the action that produces the most well-being is right, and all other actions are wrong, and _satisficing utilitarianism_, according to which within any set of options, an action is right if it produces _enough_ well-being.
+The main alternatives to scalar utilitarianism are _maximizing utilitarianism_, the view that within any set of options, the action that produces the most wellbeing is right, and all other actions are wrong, and _satisficing utilitarianism_, according to which within any set of options, an action is right if it produces _enough_ wellbeing.
 
-External links:
+_External links:_
 
 - Sinhababu, N. (2018). [Scalar Consequentialism the Right Way](https://link.springer.com/article/10.1007%2Fs11098-017-0998-y). _Philosophical Studies_. 175: 3131–3144.
 - Norcross, A. (2006). [The Scalar Approach to Utilitarianism](https://onlinelibrary.wiley.com/doi/10.1002/9780470776483.ch15). In West, H. (ed.), _The Blackwell Guide to Mill's Utilitarianism_. Hoboken, New Jersey: Wiley-Blackwell. pp. 217–232.
@@ -667,11 +668,11 @@ External links:
 <details>
 <summary>Sentiocentrism / pathocentrism<span class="icon"></span></summary>
 
-_→ Main article: [The expanding moral circle](/utilitarianism-and-practical-ethics#the-expanding-moral-circle)_
+_→ Main article:_ [_The expanding moral circle_](/utilitarianism-and-practical-ethics#the-expanding-moral-circle)
 
 Sentiocentrism, or pathocentrism, is the view that we should extend our moral concern to all _sentient beings_, meaning every individual capable of experiencing positive or negative conscious states. Sentience is seen as the characteristic that entitles individuals to moral concern. This includes humans and probably many non-human animals, but not plants or other entities that are non-sentient.
 
-Many consequentialist views, including utilitarianism, accept sentiocentrism. As a result, these views tend to reject _[speciesism](https://www.animal-ethics.org/ethics-animals-section/speciesism/)_, the practice of giving some sentient individuals less moral consideration than others based on their species membership.
+Many consequentialist views, including utilitarianism, accept sentiocentrism. As a result, these views tend to reject [_speciesism_](https://www.animal-ethics.org/ethics-animals-section/speciesism/), the practice of giving some sentient individuals less moral consideration than others based on their species membership.
 
 The main alternatives to sentiocentrism are _anthropocentrism_, the view that human beings deserve (overwhelmingly) greater moral concern than other beings, and _biocentrism_, which extends equal moral consideration to all living beings, including non-sentient ones like plants.
 
@@ -680,29 +681,29 @@ The main alternatives to sentiocentrism are _anthropocentrism_, the view that hu
 <details>
 <summary>Single-level utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Multi-level utilitarianism versus single-level utilitarianism](/types-of-utilitarianism#multi-level-utilitarianism-versus-single-level-utilitarianism)_
+_→ Main article:_ [_Multi-level utilitarianism versus single-level utilitarianism_](/types-of-utilitarianism#multi-level-utilitarianism-versus-single-level-utilitarianism)
 
 Single-level utilitarianism is the view that utilitarianism should be understood as both a criterion of rightness and a decision procedure. A criterion of rightness tells us what it takes for an action (or rule, policy, etc.) to be right or wrong. A decision procedure is something that we use when thinking about what to do.
 
-To our knowledge, no one has ever defended single-level utilitarianism, including the classical utilitarians.[^34] Deliberately calculating the expected consequences of all our actions is error-prone and risks falling into decision paralysis.
+To our knowledge, no one has ever defended single-level utilitarianism, including the classical utilitarians.35 Deliberately calculating the expected consequences of all our actions is error-prone and risks falling into decision paralysis.
 
-The main alternative to single-level utilitarianism is _multi-level utilitarianism_, the view that individuals should usually follow tried-and-tested rules of thumb, or _heuristics_, rather than trying to calculate which action will produce the most well-being. Thus, multi-level utilitarianism understands utilitarianism as a criterion of rightness, not as a decision procedure.
+The main alternative to single-level utilitarianism is _multi-level utilitarianism_, the view that individuals should usually follow tried-and-tested rules of thumb, or _heuristics_, rather than trying to calculate which action will produce the most wellbeing. Thus, multi-level utilitarianism understands utilitarianism as a criterion of rightness, not as a decision procedure.
 
-External links:
+_External links:_
 
-- Hare, R.M. (1981). Chapters 1–3, _[Moral Thinking: Its Methods, Levels, and Point](https://oxford.universitypressscholarship.com/view/10.1093/0198246609.001.0001/acprof-9780198246602)_. Oxford: Oxford University Press.
-- Roger Crisp (1997). [Routledge Philosophy Guidebook to Mill on Utilitarianism](https://philpapers.org/rec/CRIRPG-2). Routledge., pp. 105–112.
+- Hare, R.M. (1981). Chapters 1–3, [_Moral Thinking: Its Methods, Levels, and Point_](https://oxford.universitypressscholarship.com/view/10.1093/0198246609.001.0001/acprof-9780198246602). Oxford: Oxford University Press.
+- Roger Crisp (1997). [_Routledge Philosophy Guidebook to Mill on Utilitarianism_](https://philpapers.org/rec/CRIRPG-2). Routledge., pp. 105–112.
 
 </details>
 
 <details>
 <summary>Speciesism<span class="icon"></span></summary>
 
-_→ Main article: [Speciesism](/utilitarianism-and-practical-ethics#speciesism)_
+_→ Main article:_ [_Speciesism_](/utilitarianism-and-practical-ethics#speciesism)
 
-Since utilitarianism accepts [impartiality](/types-of-utilitarianism#impartiality-and-the-equal-consideration-of-interests), it considers not only the well-being of humans but also the well-being of non-human animals. Consequently, utilitarianism rejects [speciesism](https://www.animal-ethics.org/ethics-animals-section/speciesism/), the practice of giving individuals less moral consideration than others based on their species membership. To give individuals moral consideration is simply to consider how one’s behavior will affect them, whether by action or omission.
+Since utilitarianism accepts [impartiality](/types-of-utilitarianism#impartiality), it considers not only the wellbeing of humans but also the wellbeing of non-human animals. Consequently, utilitarianism rejects [_speciesism_](https://www.animal-ethics.org/ethics-animals-section/speciesism/), the practice of giving individuals less moral consideration than others based on their species membership. To give individuals moral consideration is simply to consider how one’s behavior will affect them, whether by action or omission.
 
-Consequently, rejecting speciesism entails giving _equal moral consideration_ to the well-being of all individuals but does not entail treating all species equally. Species membership is not morally relevant _in itself_, but individuals belonging to different species may differ in other ways that do matter morally. In particular, it is likely that individuals from different species do not have the same capacity for conscious experience—for instance, because of the differing numbers of neurons in their brains. Since utilitarians believe that [only sentience matters morally in itself](/utilitarianism-and-practical-ethics#the-expanding-moral-circle), the utilitarian concern for individuals is proportional to their capacity for conscious experience. It is perfectly consistent with a rejection of speciesism to say we should equally consider the well-being of a fish and a chimpanzee, without implying that they have the capacity to suffer to the same degree and deserve equal treatment.
+Consequently, rejecting speciesism entails giving _equal moral consideration_ to the wellbeing of all individuals but does not entail treating all species equally. Species membership is not morally relevant _in itself_, but individuals belonging to different species may differ in other ways that do matter morally. In particular, it is likely that individuals from different species do not have the same capacity for conscious experience—for instance, because of the differing numbers of neurons in their brains. Since utilitarians believe that [only sentience matters morally in itself](/utilitarianism-and-practical-ethics#the-expanding-moral-circle), the utilitarian concern for individuals is proportional to their capacity for conscious experience. It is perfectly consistent with a rejection of speciesism to say we should equally consider the wellbeing of a fish and a chimpanzee, without implying that they have the capacity to suffer to the same degree and deserve equal treatment.
 
 An implication of rejecting speciesism is to take improving [farm animal welfare](/acting-on-utilitarianism#farm-animal-welfare) very seriously as a moral priority.
 
@@ -711,49 +712,50 @@ An implication of rejecting speciesism is to take improving [farm animal welfare
 <details>
 <summary>Supererogation<span class="icon"></span></summary>
 
-_→ Main article: [Demandingness](/utilitarianism-and-practical-ethics#demandingness)_
+_→ Main article:_ [_Demandingness_](/utilitarianism-and-practical-ethics#demandingness)
 
 Many ethical theories posit that some actions are _supererogatory_; that is, they are morally good but not required. In contrast, most consequentialist theories, including utilitarianism, deny that supererogatory actions exist. Utilitarianism requires us to always act such as to bring about the best outcome. The theory leaves no room for actions that are permissible yet do not bring about the best consequences. Any time you can do more to help other people than you can to help yourself, you should do so. For example, if you could sacrifice your life to save the lives of several other people, then, other things being equal, according to utilitarianism, you ought to do so. This makes utilitarianism a very [demanding](/objections-to-utilitarianism/demandingness) ethical theory.
 
-External links: [Supererogation](https://plato.stanford.edu/entries/supererogation/), Stanford Encyclopedia of Philosophy
+_External links:_ [Supererogation](https://plato.stanford.edu/entries/supererogation/), Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Total view (population ethics)<span class="icon"></span></summary>
 
-_→ Main article: [Total view (population ethics)](/population-ethics#the-total-view)_
+_→ Main article:_ [_Total view (population ethics)_](/population-ethics#the-total-view)
 
-According to the total view, one outcome is better than another if and only if it contains greater total well-being, even if that is in virtue of simply having more people.
+The total view of population ethics regards one outcome as better than another if and only if it contains greater total wellbeing, even if that is in virtue of simply having more people.
 
-Importantly, one population may have greater total well-being than another in virtue of having more people. One way to calculate this total is to multiply the number of individuals with their average quality of life. For example, the total view regards a world with 100 inhabitants at average well-being level 10 as just as good as another world with 200 inhabitants at well-being level 5—both worlds contain 1,000 units of well-being.
+Importantly, one population may have greater total wellbeing than another in virtue of having more people. One way to calculate this total is to multiply the number of individuals with their average quality of life. For example, the total view regards a world with 100 inhabitants at average wellbeing level 10 as just as good as another world with 200 inhabitants at wellbeing level 5—both worlds contain 1,000 units of wellbeing.
 
-Thus, the total view implies that we can improve the world in two ways: either we improve the quality of life of existing people or we increase the number of people living positive lives. So, for example, the total view regards having a child that lives a happy and fulfilled life as something that makes the world better, other things being equal, since it adds to the total sum of well-being.[^35] In practice, there are often trade-offs between making existing people happier and creating additional happy people. On a planet with limited resources, adding more people to an already large population may at some point diminish the quality of life of everyone else severely enough that total well-being decreases.
+Thus, the total view implies that we can improve the world in two ways: either we improve the quality of life of existing people or we increase the number of people living positive lives. So, for example, the total view regards having a child that lives a happy and fulfilled life as something that makes the world better, other things being equal, since it adds to the total sum of wellbeing.36 In practice, there are often trade-offs between making existing people happier and creating additional happy people. On a planet with limited resources, adding more people to an already large population may at some point diminish the quality of life of everyone else severely enough that total wellbeing decreases.
 
-The total view’s foremost practical implication is[giving great importance](/utilitarianism-and-practical-ethics#longtermism) to ensuring the long-term flourishing of civilization. Since the total well-being enjoyed by all future people is potentially enormous, according to the total view, the [mitigation of existential risks](/acting-on-utilitarianism#existential-risk-reduction)—which threaten to destroy this immense future value—is one of the principal moral issues facing humanity.
+The total view’s foremost practical implication is [giving great importance](/utilitarianism-and-practical-ethics#longtermism) to ensuring the long-term flourishing of civilization. Since the total wellbeing enjoyed by all future people is potentially enormous, according to the total view, the [mitigation of existential risks](/acting-on-utilitarianism#existential-risk-reduction)—which threaten to destroy this immense future value—is one of the principal moral issues facing humanity.
 
-The main alternatives to the total view are the _[average view](/population-ethics#the-average-view)_, according to which one outcome is better than another if and only if it contains greater average well-being, and _[person-affecting views](/population-ethics#person-affecting-views-and-the-procreative-asymmetry)_, a family of views that share the intuition that an act can only be good/bad if it is good/bad _for_ someone. Standard person-affecting views stand in opposition to the total view since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
+The main alternatives to the total view are the [_average view_](/population-ethics#the-average-view), according to which one outcome is better than another if and only if it contains greater average wellbeing, and [_person-affecting views_](/population-ethics#person-affecting-views-and-the-procreative-asymmetry), a family of views that share the intuition that an act can only be good/bad if it is good/bad _for_ someone. Standard person-affecting views stand in opposition to the total view since they entail that there is no moral good in bringing new people into existence because nonexistence means there is no one for whom it could be good to be created.
 
-External links:
+_External links:_
 
-- Greaves, H. (2017). [Population Axiology](https://doi.org/10.1111/phc3.12442). _Philosophy Compass_. 12.
-- [The Repugnant Conclusion](https://plato.stanford.edu/archives/spr2017/entries/repugnant-conclusion/), The Stanford Encyclopedia of Philosophy
+Greaves, H. (2017). [Population Axiology](https://doi.org/10.1111/phc3.12442). _Philosophy Compass_. 12.
+
+[The Repugnant Conclusion](https://plato.stanford.edu/archives/spr2017/entries/repugnant-conclusion/), The Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Utilitarianism<span class="icon"></span></summary>
 
-_→ Main article: [Utilitarianism](/introduction-to-utilitarianism#what-is-utilitarianism)_
+_→ Main article:_ [_Utilitarianism_](/introduction-to-utilitarianism#explaining-what-utilitarianism-is)
 
-Utilitarianism is the view that one morally ought to promote just the sum total of well-being.[^36] The four elements shared by all utilitarian theories include (i) [consequentialism](/types-of-utilitarianism#consequentialism), (ii) [welfarism](/types-of-utilitarianism#welfarism), (iii) [impartiality](/types-of-utilitarianism#impartiality-and-the-equal-consideration-of-interests), and (iv) [aggregationism](/types-of-utilitarianism#aggregationism).
+Utilitarianism is the view that one morally ought to promote just the sum total of well-being.37 The four elements shared by all utilitarian theories include (i) [consequentialism](/types-of-utilitarianism#consequentialism), (ii) [welfarism](/types-of-utilitarianism#welfarism), (iii) [impartiality](/types-of-utilitarianism#impartiality), and (iv) [aggregationism](/types-of-utilitarianism#aggregationism).
 
 </details>
 
 <details>
 <summary>Utility<span class="icon"></span></summary>
 
-In philosophy, the term _utility_ refers to a measure of moral value. Traditionally, utility was used to denote related concepts such as well-being, happiness, and pleasure, which are the fundamental units of value in utilitarian ethics.
+In philosophy, the term _utility_ refers to a measure of moral value. Traditionally, utility was used to denote related concepts such as wellbeing, happiness, and pleasure, which are the fundamental units of value in utilitarian ethics.
 
 In contemporary contexts, utility is predominantly used as an economic concept (as in “utility function”) to describe a person’s preference ordering over a set of alternatives.
 
@@ -762,12 +764,11 @@ In contemporary contexts, utility is predominantly used as an economic concept (
 <details>
 <summary>Utility monster<span class="icon"></span></summary>
 
-The utility monster is a thought experiment devised by Robert Nozick to criticize utilitarianism.[^37] Nozick imagines a hypothetical being, the utility monster, which has the capacity for generating much higher levels of well-being than anyone else. From a utilitarian perspective, Nozick writes, the existence of such a being would require providing it with immense resources to increase its well-being, even at significant sacrifice to others.
+The utility monster is a thought experiment devised by Robert Nozick to criticize utilitarianism.38 Nozick imagines a hypothetical being, the utility monster, which has the capacity for generating much higher levels of wellbeing than anyone else. From a utilitarian perspective, Nozick writes, the existence of such a being would require providing it with immense resources to increase its wellbeing, even at significant sacrifice to others.
 
 For a utilitarian critique, see:
 
-- Chappell, R.Y. (2021). [Negative Utility Monsters](https://dx.doi.org/10.1017/s0953820821000169). _Utilitas_ 33 (4): 417-421. \
-  (Note that Chappell is a co-author of this website.)
+Chappell, R.Y. (2021). [Negative Utility Monsters](https://dx.doi.org/10.1017/s0953820821000169). _Utilitas_ 33 (4): 417-421. (Note that Chappell is a co-author of this website.)
 
 </details>
 
@@ -776,35 +777,35 @@ For a utilitarian critique, see:
 
 According to virtue ethics, morality is fundamentally about having or developing a virtuous character.
 
-The main alternatives to virtue ethics are _[consequentialism](https://plato.stanford.edu/entries/consequentialism/)_, according to which what fundamentally matters is promoting good consequences, and _[deontology](https://plato.stanford.edu/entries/ethics-deontological/)_, which views morality as being about following a system of duties and rules, like “Do Not Lie” or “Do Not Steal”.
+The main alternatives to virtue ethics are [_consequentialism_](https://plato.stanford.edu/entries/consequentialism/), according to which what fundamentally matters is promoting good consequences, and [_deontology_](https://plato.stanford.edu/entries/ethics-deontological/), which views morality as being about following a system of duties and rules, like “Do Not Lie” or “Do Not Steal”.
 
-External links: [Virtue Ethics](https://plato.stanford.edu/entries/ethics-virtue/), The Stanford Encyclopedia of Philosophy
+_External links:_ [Virtue Ethics](https://plato.stanford.edu/entries/ethics-virtue/), The Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Welfarism<span class="icon"></span></summary>
 
-_→ Main article: [Welfarism](/types-of-utilitarianism#welfarism)_
+_→ Main article:_ [_Welfarism_](/types-of-utilitarianism#welfarism)
 
-Welfarism is the view that only the _welfare_(also called _well-being_) of individuals determines how good a particular state of the world is. Philosophers use the term well-being to describe everything that is good for a person in itself, as opposed to things only instrumentally good for a person. For example, money can buy many useful things and is thus good for a person instrumentally, but it is not a component of their well-being.
+Welfarism is the view that only the _welfare_ (also called _well-being_) of individuals determines how good a particular state of the world is. Philosophers use the term wellbeing to describe everything that is good for a person in itself, as opposed to things only instrumentally good for a person. For example, money can buy many useful things and is thus good for a person instrumentally, but it is not a component of their wellbeing.
 
 Welfarism is one of the [four elements of utilitarian ethical theories](/types-of-utilitarianism#the-four-elements-of-utilitarianism).
 
-There are various types of welfarism, each of which regards different things as the constituents of well-being. The three most prevalent welfarist theories are _[hedonism](/theories-of-wellbeing#hedonism)_, [desire theories](/theories-of-wellbeing#desire-theories), and [objective list theories](/theories-of-wellbeing#objective-list-theories).
+There are various types of welfarism, each of which regards different things as the constituents of wellbeing. The three most prevalent welfarist theories are [_hedonism_](/theories-of-wellbeing#hedonism), [_desire theories_](/theories-of-wellbeing#desire-theories), and [_objective list theories_](/theories-of-wellbeing#objective-list-theories).
 
-External links: [Welfarism](https://plato.stanford.edu/entries/well-being/#Wel), The Stanford Encyclopedia of Philosophy
+_External links:_ [Welfarism](https://plato.stanford.edu/entries/well-being/#Wel), The Stanford Encyclopedia of Philosophy
 
 </details>
 
 <details>
 <summary>Well-being / Welfare<span class="icon"></span></summary>
 
-_→ Main article: [Theories of Well-Being](/theories-of-wellbeing)_
+_→ Main article:_ [_Theories of Well-Being_](/theories-of-wellbeing)
 
 Philosophers use the term well-being to describe everything that is good for a person in itself, as opposed to things only instrumentally good for a person. For example, money can buy many useful things and is thus good for a person instrumentally, but it is not a component of their well-being.
 
-External links: [Well-being](https://plato.stanford.edu/entries/well-being/), The Stanford Encyclopedia of Philosophy
+_External links:_ [Well-being](https://plato.stanford.edu/entries/well-being/), The Stanford Encyclopedia of Philosophy
 
 </details>
 

--- a/content/resources-and-further-reading.md
+++ b/content/resources-and-further-reading.md
@@ -1,6 +1,7 @@
 ---
 title: "Resources and Further Reading"
-date: 2022-08-08T10:10:50-04:00
+date: 2023-01-01T10:10:50-04:00
+updated: 2023, Jan 8th - in sync with website
 draft: false
 menu: "main"
 image: "/img/Utilitarianism-Website-Logo.png"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 
 <title>
   {{ block "title" . }}
-    {{ with .Params.Title }}{{ . }} |{{ end }}{{ .Site.Title }}
+    {{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}
   {{ end }}
 
 </title>


### PR DESCRIPTION
manually checked everything (footnotes too 😅 ) - identical to current website, but I added a section for _Richard Hare_ with a link to our page for him 👍 

See comment on footnote `37` (under **Utilitarianism** section) where we link to _Wikipedia_ **Population Ethics** rather than our own page 🤔  -- should we put in both links (first link ours, and then in parentheses `(also see _Wikipedia_)`) 🤷 

Cheers!