### PR TITLE
Textbook chapters

### DIFF
--- a/assets/scss/unsorted.scss
+++ b/assets/scss/unsorted.scss
@@ -373,3 +373,20 @@ hr {
     height: 30px;
   }
 }
+
+
+.square {
+  float: left;
+  margin-right: 40px;
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border-radius: 10px;
+}
+
+.textbook-chapters-descriptions {
+  .guest-essay {
+    min-height: initial;
+    margin-bottom: 0;
+  }
+}

--- a/assets/scss/unsorted.scss
+++ b/assets/scss/unsorted.scss
@@ -382,12 +382,18 @@ hr {
   p {
     margin: 0;
   }
+
+  .objections {
+    margin-left: 35px;
+  }
   
   .square {
     border-radius: 5px;
     height: calc(100% - 20px);
     position: absolute;
     width: 30px;
+    text-align: center;
+    color: white;
   }
 
   .guest-essay {

--- a/assets/scss/unsorted.scss
+++ b/assets/scss/unsorted.scss
@@ -374,19 +374,31 @@ hr {
   }
 }
 
-
-.square {
-  float: left;
-  margin-right: 40px;
-  position: relative;
-  width: 100px;
-  height: 100px;
-  border-radius: 10px;
-}
-
 .textbook-chapters-descriptions {
+  h2 {
+    font-size: 20px;
+  }
+
+  p {
+    margin: 0;
+  }
+  
+  .square {
+    border-radius: 5px;
+    height: calc(100% - 20px);
+    position: absolute;
+    width: 30px;
+  }
+
   .guest-essay {
-    min-height: initial;
+    border-radius: 10px;
     margin-bottom: 0;
+    min-height: initial;
+    padding: 10px;
+    position: relative;
+  }
+
+  .title-and-description {
+    margin-left: 40px;
   }
 }

--- a/content/arguments-for-utilitarianism.md
+++ b/content/arguments-for-utilitarianism.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 3
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This chapter explains reflective equilibrium as a moral methodology, and presents several arguments for utilitarianism (and similar consequentialist views) over competing approaches to ethics."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#012147"
+gradientBottom: "#084BC7"
 ---
 
 {{< TOC >}}

--- a/content/arguments-for-utilitarianism.md
+++ b/content/arguments-for-utilitarianism.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 3
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This chapter explains reflective equilibrium as a moral methodology, and presents several arguments for utilitarianism (and similar consequentialist views) over competing approaches to ethics."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/introduction-to-utilitarianism.md
+++ b/content/introduction-to-utilitarianism.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 1
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This chapter introduces utilitarianism, and its major costs and benefits as a moral theory."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#0c3b5b"
+gradientBottom: "#236d9f"
 ---
 
 > _"The utilitarian doctrine is, that happiness is desirable, and the only thing desirable, as an end; all other things being only desirable as means to that end."_

--- a/content/introduction-to-utilitarianism.md
+++ b/content/introduction-to-utilitarianism.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 1
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This chapter introduces utilitarianism, and its major costs and benefits as a moral theory."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 > _"The utilitarian doctrine is, that happiness is desirable, and the only thing desirable, as an end; all other things being only desirable as means to that end."_

--- a/content/near-utilitarian-alternatives.md
+++ b/content/near-utilitarian-alternatives.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 7
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "There are several ways to reject aspects of utilitarianism while remaining on board with the general thrust of the theory (at least in practice). This chapter explores a range of such near-utilitarian views, to demonstrate the robustness of utilitarianism's practical recommendations.  Even if you think the theory is technically false, you may nonetheless have good grounds to largely agree with its practical verdicts."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/near-utilitarian-alternatives.md
+++ b/content/near-utilitarian-alternatives.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 7
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "There are several ways to reject aspects of utilitarianism while remaining on board with the general thrust of the theory (at least in practice). This chapter explores a range of such near-utilitarian views, to demonstrate the robustness of utilitarianism's practical recommendations.  Even if you think the theory is technically false, you may nonetheless have good grounds to largely agree with its practical verdicts."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#305D9C"
+gradientBottom: "#1F2A70"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/_index.md
+++ b/content/objections-to-utilitarianism/_index.md
@@ -8,8 +8,8 @@ weight: 8
 page: 0
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This article explains four general strategies for responding to objections to utilitarianism, before introducing the most influential specific objections to the theory."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#1F2A70"
+gradientBottom: "#1F2A70"
 ---
 
 > _"Bernard Williams...concluded a lengthy attack on utilitarianism by remarking: ‘The day cannot be too far off in which we hear no more of it.’ It is now more than forty years since Williams made that comment, but we continue to hear plenty about utilitarianism."_ \

--- a/content/objections-to-utilitarianism/_index.md
+++ b/content/objections-to-utilitarianism/_index.md
@@ -9,7 +9,7 @@ page: 0
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This article explains four general strategies for responding to objections to utilitarianism, before introducing the most influential specific objections to the theory."
 gradientTop: "#1F2A70"
-gradientBottom: "#1F2A70"
+gradientBottom: "#1F1E70"
 ---
 
 > _"Bernard Williams...concluded a lengthy attack on utilitarianism by remarking: ‘The day cannot be too far off in which we hear no more of it.’ It is now more than forty years since Williams made that comment, but we continue to hear plenty about utilitarianism."_ \

--- a/content/objections-to-utilitarianism/_index.md
+++ b/content/objections-to-utilitarianism/_index.md
@@ -8,6 +8,8 @@ weight: 8
 page: 0
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "This article explains four general strategies for responding to objections to utilitarianism, before introducing the most influential specific objections to the theory."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 > _"Bernard Williams...concluded a lengthy attack on utilitarianism by remarking: ‘The day cannot be too far off in which we hear no more of it.’ It is now more than forty years since Williams made that comment, but we continue to hear plenty about utilitarianism."_ \

--- a/content/objections-to-utilitarianism/alienation.md
+++ b/content/objections-to-utilitarianism/alienation.md
@@ -9,8 +9,8 @@ weight: 6
 page: 6
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Utilitarianism's strict impartiality threatens to alienate us from much that we hold dear. This article explores how defenders of the view might best address such concerns. The sophisticated utilitarian strategy recommends adopting motivations other than explicitly utilitarian ones. The subsumption strategy instead argues that direct concern for particular goods or individuals can be subsumed within straightforwardly utilitarian motivations. By suitably combining the two, utilitarians may be able to offer a full response to the alienation objection."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#822FA8"
+gradientBottom: "#531694"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/alienation.md
+++ b/content/objections-to-utilitarianism/alienation.md
@@ -9,6 +9,8 @@ weight: 6
 page: 6
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Utilitarianism's strict impartiality threatens to alienate us from much that we hold dear. This article explores how defenders of the view might best address such concerns. The sophisticated utilitarian strategy recommends adopting motivations other than explicitly utilitarian ones. The subsumption strategy instead argues that direct concern for particular goods or individuals can be subsumed within straightforwardly utilitarian motivations. By suitably combining the two, utilitarians may be able to offer a full response to the alienation objection."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/demandingness.md
+++ b/content/objections-to-utilitarianism/demandingness.md
@@ -9,6 +9,8 @@ weight: 2
 page: 2
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "In directing us to choose the impartially best outcome, even at significant cost to ourselves, utilitarianism can seem an incredibly demanding theory. This page explores whether this feature of utilitarianism is objectionable, and if so, how defenders of the view might best respond."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 > _Utilitarianism doesn't ask us to be morally perfect. It asks us to face up to our moral limitations and do as much as we humanly can to overcome them._

--- a/content/objections-to-utilitarianism/demandingness.md
+++ b/content/objections-to-utilitarianism/demandingness.md
@@ -9,8 +9,8 @@ weight: 2
 page: 2
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "In directing us to choose the impartially best outcome, even at significant cost to ourselves, utilitarianism can seem an incredibly demanding theory. This page explores whether this feature of utilitarianism is objectionable, and if so, how defenders of the view might best respond."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#371E87"
+gradientBottom: "#571B9E"
 ---
 
 > _Utilitarianism doesn't ask us to be morally perfect. It asks us to face up to our moral limitations and do as much as we humanly can to overcome them._

--- a/content/objections-to-utilitarianism/equality.md
+++ b/content/objections-to-utilitarianism/equality.md
@@ -9,6 +9,8 @@ weight: 3
 page: 3
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Utilitarianism is concerned with the overall well-being of individuals in the population, but many object that justice requires an additional concern for how this well-being is distributed across individuals. This article examines this objection, and how utilitarians might best respond."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/equality.md
+++ b/content/objections-to-utilitarianism/equality.md
@@ -9,8 +9,8 @@ weight: 3
 page: 3
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Utilitarianism is concerned with the overall well-being of individuals in the population, but many object that justice requires an additional concern for how this well-being is distributed across individuals. This article examines this objection, and how utilitarians might best respond."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#571B9E"
+gradientBottom: "#430A4A"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/mere-means.md
+++ b/content/objections-to-utilitarianism/mere-means.md
@@ -9,6 +9,8 @@ weight: 4
 page: 4
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Critics often allege that utilitarianism objectionably instrumentalizes people—treating us as mere means to the greater good, rather than properly valuing individuals as ends in themselves. In this article, we assess whether this is a fair objection."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/mere-means.md
+++ b/content/objections-to-utilitarianism/mere-means.md
@@ -9,8 +9,8 @@ weight: 4
 page: 4
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Critics often allege that utilitarianism objectionably instrumentalizes people—treating us as mere means to the greater good, rather than properly valuing individuals as ends in themselves. In this article, we assess whether this is a fair objection."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#430A4A"
+gradientBottom: "#5F3091"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/rights.md
+++ b/content/objections-to-utilitarianism/rights.md
@@ -9,6 +9,8 @@ weight: 1
 page: 1
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Many find it objectionable that utilitarianism seemingly licenses outrageous rights violations in certain hypothetical scenarios, killing innocent people for the greater good. This article explores how utilitarians might best respond."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/rights.md
+++ b/content/objections-to-utilitarianism/rights.md
@@ -9,8 +9,8 @@ weight: 1
 page: 1
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Many find it objectionable that utilitarianism seemingly licenses outrageous rights violations in certain hypothetical scenarios, killing innocent people for the greater good. This article explores how utilitarians might best respond."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#1F1E70"
+gradientBottom: "#371E87"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/separateness-of-persons.md
+++ b/content/objections-to-utilitarianism/separateness-of-persons.md
@@ -9,6 +9,8 @@ weight: 5
 page: 5
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "The idea that utilitarianism neglects the 'separateness of persons' has proven to be a widely influential objection. But it is one that is difficult to pin down. This article explores three candidate interpretations of the objection, and how utilitarians can respond to each."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/separateness-of-persons.md
+++ b/content/objections-to-utilitarianism/separateness-of-persons.md
@@ -9,8 +9,8 @@ weight: 5
 page: 5
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "The idea that utilitarianism neglects the 'separateness of persons' has proven to be a widely influential objection. But it is one that is difficult to pin down. This article explores three candidate interpretations of the objection, and how utilitarians can respond to each."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#5F3091"
+gradientBottom: "#822FA8"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/special-obligations.md
+++ b/content/objections-to-utilitarianism/special-obligations.md
@@ -9,8 +9,8 @@ weight: 7
 page: 7
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "It is usually thought that certain relationships, like parenthood or guardianship, give rise to special obligations to protect those who fall under our care. If utilitarianism denied this, for example by recommending that parents neglect their own children in order to save a larger number of strangers, that might seem to count seriously against the theory. This article explores how utilitarians might best respond."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#531694"
+gradientBottom: "#260380"
 ---
 
 {{< TOC >}}

--- a/content/objections-to-utilitarianism/special-obligations.md
+++ b/content/objections-to-utilitarianism/special-obligations.md
@@ -9,6 +9,8 @@ weight: 7
 page: 7
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "It is usually thought that certain relationships, like parenthood or guardianship, give rise to special obligations to protect those who fall under our care. If utilitarianism denied this, for example by recommending that parents neglect their own children in order to save a larger number of strangers, that might seem to count seriously against the theory. This article explores how utilitarians might best respond."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/population-ethics.md
+++ b/content/population-ethics.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 5
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Population ethics tackles questions like how we should weigh new lives against existing lives, and how we should balance quantity and quality of life (when comparing different-sized populations). This chapter critically surveys five major approaches to population ethics: the total view, the average view, variable value theories, critical level (and critical range) theories, and person-affecting views."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/population-ethics.md
+++ b/content/population-ethics.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 5
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Population ethics tackles questions like how we should weigh new lives against existing lives, and how we should balance quantity and quality of life (when comparing different-sized populations). This chapter critically surveys five major approaches to population ethics: the total view, the average view, variable value theories, critical level (and critical range) theories, and person-affecting views."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#1B7CCC"
+gradientBottom: "#089FD1"
 ---
 
 {{< TOC >}}

--- a/content/resources-and-further-reading.md
+++ b/content/resources-and-further-reading.md
@@ -5,6 +5,7 @@ updated: 2023, Jan 8th - in sync with website
 draft: false
 menu: "main"
 image: "/img/Utilitarianism-Website-Logo.png"
+description: "Resources and further reading about utilitarianism."
 ---
 
 <div class="hide-TOC-children-hack">

--- a/content/resources-and-further-reading.md
+++ b/content/resources-and-further-reading.md
@@ -6,8 +6,8 @@ draft: false
 menu: "main"
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Resources and further reading about utilitarianism."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#260380"
+gradientBottom: "#012147"
 ---
 
 <div class="hide-TOC-children-hack">

--- a/content/resources-and-further-reading.md
+++ b/content/resources-and-further-reading.md
@@ -6,6 +6,8 @@ draft: false
 menu: "main"
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Resources and further reading about utilitarianism."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 <div class="hide-TOC-children-hack">

--- a/content/textbook.md
+++ b/content/textbook.md
@@ -11,12 +11,4 @@ Below is an online textbook that aims to provide a concise, accessible, and enga
 
 For a high-school level introduction, see [Utilitarianism: Simply Explained](/utilitarianism-for-high-school-students/)
 
-<div class="textbook-hack">
-<div class="homepage-body">
-<div class="dark-background">
-
 {{< textbook-contents >}}
-
-</div>
-</div>
-</div>

--- a/content/theories-of-wellbeing.md
+++ b/content/theories-of-wellbeing.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 4
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Explores the three major theories of well-being, or what makes a life good for the individual living it: hedonism, desire theory, and objective list theory."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 > _“To what shall the character of utility be ascribed, if not to that which is a source of pleasure?”_ <br> \- [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham)[^1]

--- a/content/theories-of-wellbeing.md
+++ b/content/theories-of-wellbeing.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 4
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Explores the three major theories of well-being, or what makes a life good for the individual living it: hedonism, desire theory, and objective list theory."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#084BC7"
+gradientBottom: "#1B7CCC"
 ---
 
 > _“To what shall the character of utility be ascribed, if not to that which is a source of pleasure?”_ <br> \- [Jeremy Bentham](/utilitarian-thinker/jeremy-bentham)[^1]

--- a/content/types-of-utilitarianism.md
+++ b/content/types-of-utilitarianism.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 2
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "After defining utilitarianism, this chapter offers a detailed analysis of its four key elements (consequentialism, welfarism, impartiality, and aggregationism). It explains the difference between maximizing, satisficing, and scalar utilitarianism, and other important distinctions between utilitarian theories."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#236d9f"
+gradientBottom: "#012147"
 ---
 
 {{< TOC >}}

--- a/content/types-of-utilitarianism.md
+++ b/content/types-of-utilitarianism.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 2
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "After defining utilitarianism, this chapter offers a detailed analysis of its four key elements (consequentialism, welfarism, impartiality, and aggregationism). It explains the difference between maximizing, satisficing, and scalar utilitarianism, and other important distinctions between utilitarian theories."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 {{< TOC >}}

--- a/content/utilitarianism-and-practical-ethics.md
+++ b/content/utilitarianism-and-practical-ethics.md
@@ -7,8 +7,8 @@ menu: "main"
 weight: 6
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Utilitarianism has important implications for how we should think about leading an ethical life. Despite giving no intrinsic weight to deontic constraints, it supports many commonsense prohibitions and virtues in practice. Its main practical difference instead lies in its emphasis on positively doing good, in more expansive and efficient ways than people typically prioritize."
-gradientTop: "#836e5d"
-gradientBottom: "#331521"
+gradientTop: "#089FD1"
+gradientBottom: "#305D9C"
 ---
 
 > Are we to extend our concern to all the beings capable of pleasure and pain whose feelings are affected by our conduct? or are we to confine our view to human happiness? The former view is the one adopted by (...) the Utilitarian school (...) it seems arbitrary and unreasonable to exclude from the end, as so conceived, any pleasure of any sentient being. <br> \- [Henry Sidgwick](/utilitarian-thinker/henry-sidgwick)[^1]

--- a/content/utilitarianism-and-practical-ethics.md
+++ b/content/utilitarianism-and-practical-ethics.md
@@ -7,6 +7,8 @@ menu: "main"
 weight: 6
 image: "/img/Utilitarianism-Website-Logo.png"
 description: "Utilitarianism has important implications for how we should think about leading an ethical life. Despite giving no intrinsic weight to deontic constraints, it supports many commonsense prohibitions and virtues in practice. Its main practical difference instead lies in its emphasis on positively doing good, in more expansive and efficient ways than people typically prioritize."
+gradientTop: "#836e5d"
+gradientBottom: "#331521"
 ---
 
 > Are we to extend our concern to all the beings capable of pleasure and pain whose feelings are affected by our conduct? or are we to confine our view to human happiness? The former view is the one adopted by (...) the Utilitarian school (...) it seems arbitrary and unreasonable to exclude from the end, as so conceived, any pleasure of any sentient being. <br> \- [Henry Sidgwick](/utilitarian-thinker/henry-sidgwick)[^1]

--- a/layouts/partials/textbook-chapter.html
+++ b/layouts/partials/textbook-chapter.html
@@ -1,9 +1,12 @@
 <div class="guest-essay">
   <div
     class="square"
-    style="background: linear-gradient(180deg, #0c3b5b 0%, #236d9f 100%);"
+    style="background: linear-gradient(180deg, {{ .Params.gradientTop }} 0%,  
+    {{ .Params.gradientBottom }} 100%);"
   >
   </div>
-  <h2>{{ .Title }}</h2>
-  <p>{{ .Params.Description }}</p>
+  <div class="title-and-description">
+    <h2>{{ .Title }}</h2>
+    <p>{{ .Params.Description }}</p>
+  </div>
 </div>

--- a/layouts/partials/textbook-chapter.html
+++ b/layouts/partials/textbook-chapter.html
@@ -1,0 +1,9 @@
+<div class="guest-essay">
+  <div
+    class="square"
+    style="background: linear-gradient(180deg, #0c3b5b 0%, #236d9f 100%);"
+  >
+  </div>
+  <h2>{{ .Title }}</h2>
+  <p>{{ .Params.Description }}</p>
+</div>

--- a/layouts/partials/textbook-chapter.html
+++ b/layouts/partials/textbook-chapter.html
@@ -1,9 +1,11 @@
 <div class="guest-essay">
   <div
     class="square"
-    style="background: linear-gradient(180deg, {{ .Params.gradientTop }} 0%,  
-    {{ .Params.gradientBottom }} 100%);"
+    style="background: linear-gradient(180deg, {{ .Params.gradientTop }} 0%, {{ .Params.gradientBottom }} 100%);"
   >
+    <span>
+      {{ .Scratch.Get "chapter" }}
+    </span>
   </div>
   <div class="title-and-description">
     <h2>{{ .Title }}</h2>

--- a/layouts/shortcodes/textbook-contents.html
+++ b/layouts/shortcodes/textbook-contents.html
@@ -8,14 +8,12 @@
     </a>
   {{ end }}
 
-  {{ with .Site.Menus.objections.Sort.ByWeight }}
-    {{ range first 7 . }}
-      <a href="{{ .URL }}">
-        {{ with .Page }}
-          {{ block "objections" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
-        {{ end }}
-      </a>
-    {{ end }}
+  {{ range first 7 .Site.Menus.objections.Sort.ByWeight }}
+    <a href="{{ .URL }}">
+      {{ with .Page }}
+        {{ block "objections" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
+      {{ end }}
+    </a>
   {{ end }}
 
   {{ range last 1 .Site.Menus.main.Sort.ByWeight }}

--- a/layouts/shortcodes/textbook-contents.html
+++ b/layouts/shortcodes/textbook-contents.html
@@ -1,28 +1,29 @@
-<div class="temp-navigation-hack">
-  <span class="footer-heading">Textbook Chapters</span>
+<div class="guest-essay-container textbook-chapters-descriptions">
 
-  <ol>
-    {{ range first 8 .Site.Menus.main.Sort.ByWeight }}
-      <li>
-        <a href="{{ .URL }}">{{ .Title }}</a>
-      </li>
-    {{ end }}
-
-    {{/* After "Objections" article list all the Objection articles */}}
-    <ul>
-      {{ with .Site.Menus.objections.Sort.ByWeight }}
-        {{ range first 7 . }}
-          <li>
-            <a href="{{ .URL }}">{{ .Title }}</a>
-          </li>
-        {{ end }}
+  {{ range first 8 .Site.Menus.main.Sort.ByWeight }}
+    <a href="{{ .URL }}">
+      {{ with .Page }}
+        {{ block "chapter" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
       {{ end }}
-    </ul>
+    </a>
+  {{ end }}
 
-    {{ range last 1 .Site.Menus.main.Sort.ByWeight }}
-      <li>
-        <a href="{{ .URL }}">{{ .Title }}</a>
-      </li>
+  {{ with .Site.Menus.objections.Sort.ByWeight }}
+    {{ range first 7 . }}
+      <a href="{{ .URL }}">
+        {{ with .Page }}
+          {{ block "objections" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
+        {{ end }}
+      </a>
     {{ end }}
-  </ol>
+  {{ end }}
+
+  {{ range last 1 .Site.Menus.main.Sort.ByWeight }}
+    <a href="{{ .URL }}">
+      {{ with .Page }}
+        {{ block "last-chapter" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
+      {{ end }}
+    </a>
+  {{ end }}
+
 </div>

--- a/layouts/shortcodes/textbook-contents.html
+++ b/layouts/shortcodes/textbook-contents.html
@@ -1,25 +1,30 @@
 <div class="guest-essay-container textbook-chapters-descriptions">
 
-  {{ range first 8 .Site.Menus.main.Sort.ByWeight }}
+  {{ range $index, $lol := first 8 .Site.Menus.main.Sort.ByWeight }}
     <a href="{{ .URL }}">
       {{ with .Page }}
-        {{ block "chapter" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
+        {{ .Scratch.Set "chapter" (add $index 1) }}
+        {{ partial "textbook-chapter.html" . }}
       {{ end }}
     </a>
   {{ end }}
 
-  {{ range first 7 .Site.Menus.objections.Sort.ByWeight }}
-    <a href="{{ .URL }}">
-      {{ with .Page }}
-        {{ block "objections" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
-      {{ end }}
-    </a>
-  {{ end }}
+  <div class="objections">
+    {{ range $index, $lol := first 7 .Site.Menus.objections.Sort.ByWeight }}
+      <a href="{{ .URL }}">
+        {{ with .Page }}
+          {{ .Scratch.Set "chapter" (add $index 1) }}
+          {{ partial "textbook-chapter.html" . }}
+        {{ end }}
+      </a>
+    {{ end }}
+  </div>
 
-  {{ range last 1 .Site.Menus.main.Sort.ByWeight }}
+  {{ range $index, $lol := last 1 .Site.Menus.main.Sort.ByWeight }}
     <a href="{{ .URL }}">
       {{ with .Page }}
-        {{ block "last-chapter" . }}{{ partial "textbook-chapter.html" . }}{{ end }}
+        {{ .Scratch.Set "chapter" (add $index 9) }}
+        {{ partial "textbook-chapter.html" . }}
       {{ end }}
     </a>
   {{ end }}


### PR DESCRIPTION
The `/textbook` page now has descriptions next to chapter titles and a gradient to make each link pretty.

Richard - no review required, added you as a reviewer for an easy link for you to click on 🤝 

📓 notes: 
- not optimized for _mobile_ yet (on small width phone screen text feels too big & objections indentation too large)
- gradient colors can be adjusted
- we could copy over the gradient into the chapter page heading when clicking on a chapter link 🤔 (rather than keeping the default blue-blue graident).