### PR TITLE
mp3 everywhere

### DIFF
--- a/assets/scss/audio.scss
+++ b/assets/scss/audio.scss
@@ -1,46 +1,35 @@
 $play-icon-color: #0b3959;
 
+.audio-player {
+  display: none;
+
+  audio {
+    width: 100%;
+  }
+}
+
+.show-player {
+  display: initial;
+}
+
 .mp3 {
-  background: #e2e5e7;
   border-radius: 50%;
   cursor: pointer;
-  height: 20px;
   margin-bottom: 12px;
   overflow: hidden;
   padding: 5px;
   position: relative;
-  width: 20px;
+  height: 24px;
+  width: 24px;
 
-  // Thank you to https://css-tricks.com/making-pure-css-playpause-button/
-  button {
-    cursor: pointer;
-
-    background-color: transparent;
-    left: -18px;
-    top: -22px;
-    position: absolute;
-
-    scale: 0.2;
-    box-sizing: border-box;
-    height: 74px;
-
-    border-color: transparent transparent transparent $play-icon-color;
-    transition: 100ms all ease;
-    will-change: border-width;
-
-    // play state
-    border-style: solid;
-    border-width: 37px 0 37px 60px;
-
-    // paused state
-    &.pause {
-      transform: translateX(-10px);
-      border-style: double;
-      border-width: 0px 0 0px 60px;
-    }
+  img {
+    transition-property: scale;
+    transition-duration: 125ms;
   }
 
   &:hover {
-    background-color: #d0d2d3;
+    img {
+      scale: 1.2;
+    }
   }
 }

--- a/assets/scss/audio.scss
+++ b/assets/scss/audio.scss
@@ -2,6 +2,7 @@ $play-icon-color: #0b3959;
 
 .audio-player {
   display: none;
+  margin-bottom: 10px;
 
   audio {
     width: 100%;
@@ -9,7 +10,7 @@ $play-icon-color: #0b3959;
 }
 
 .show-player {
-  display: initial;
+  display: block;
 }
 
 .mp3 {

--- a/assets/scss/audio.scss
+++ b/assets/scss/audio.scss
@@ -1,0 +1,46 @@
+$play-icon-color: #0b3959;
+
+.mp3 {
+  background: #e2e5e7;
+  border-radius: 50%;
+  cursor: pointer;
+  height: 20px;
+  margin-bottom: 12px;
+  overflow: hidden;
+  padding: 5px;
+  position: relative;
+  width: 20px;
+
+  // Thank you to https://css-tricks.com/making-pure-css-playpause-button/
+  button {
+    cursor: pointer;
+
+    background-color: transparent;
+    left: -18px;
+    top: -22px;
+    position: absolute;
+
+    scale: 0.2;
+    box-sizing: border-box;
+    height: 74px;
+
+    border-color: transparent transparent transparent $play-icon-color;
+    transition: 100ms all ease;
+    will-change: border-width;
+
+    // play state
+    border-style: solid;
+    border-width: 37px 0 37px 60px;
+
+    // paused state
+    &.pause {
+      transform: translateX(-10px);
+      border-style: double;
+      border-width: 0px 0 0px 60px;
+    }
+  }
+
+  &:hover {
+    background-color: #d0d2d3;
+  }
+}

--- a/assets/scss/lol.scss
+++ b/assets/scss/lol.scss
@@ -13,6 +13,7 @@ $breakpoint-tablet: 850px;
 @import "buttons";
 @import "footnotes";
 @import "unsorted";
+@import "audio";
 @import "search";
 @import "mobilenav";
 @import "mobile";

--- a/assets/scss/mobile.scss
+++ b/assets/scss/mobile.scss
@@ -1,6 +1,21 @@
 @media only screen and (max-width: 990px) {
   .pdf-download {
-    display: none;
+    display: block;
+    padding-right: 16px;
+    position: relative;
+    right: 0;
+    text-align: right;
+    top: 0;
+
+    a {
+      text-decoration: none;
+    }
+
+    div {
+      transform: translate(15px, 2px);
+      display: inline-block;
+      margin-bottom: 0;
+    }
   }
 }
 
@@ -105,7 +120,7 @@
     height: 120px;
     position: relative;
     width: 120px;
- 
+
     .image-credit {
       background-color: white;
       border-radius: 5px;
@@ -119,7 +134,7 @@
       transform: translate(-50%, 6px);
       white-space: nowrap;
     }
-    
+
   }
 
   .thinker-name {

--- a/assets/scss/unsorted.scss
+++ b/assets/scss/unsorted.scss
@@ -162,7 +162,7 @@ h1 {
     .clickable {
       height:100%;
       left: 0;
-      position:absolute; 
+      position:absolute;
       top:0;
       width:100%;
       z-index: 1;
@@ -401,6 +401,13 @@ hr {
   .pdf-icon {
     width: 30px;
     height: 30px;
+
+    transition-property: scale;
+    transition-duration: 125ms;
+
+    &:hover {
+      scale: 1.2;
+    }
   }
 }
 

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -15,8 +15,8 @@
       {{ .Params.gradientTop }}
     {{ else }}
       {{ print "#0c3b5b" }}
-    {{ end }} 0%,  
-                                              {{ if (isset .Params "gradientBottom") }}
+    {{ end }} 0%,
+    {{ if (isset .Params "gradientBottom") }}
       {{ .Params.gradientBottom }}
     {{ else }}
       {{ print "#236d9f" }}

--- a/layouts/partials/PDF.html
+++ b/layouts/partials/PDF.html
@@ -1,51 +1,51 @@
-<div class="pdf-download">
-  {{ with .Page }}
-    {{ $myVar := print .Params.title "_Utilitarianism_net" }}
-    {{ $myVar2 := replaceRE "( |,|_|-|—|:|'|\\.|  )" "_" $myVar }}
-    {{ $myVar3 := replace $myVar2 "__" "_" }}
-    {{ $myVar4 := replace $myVar3 "__" "_" }}
-
-
-    <a href="/pdf/{{ $myVar4 }}.pdf">
-      <img
-        src="/img/pdf.svg"
-        class="pdf-icon"
-        title="Download as PDF"
-        alt="PDF download"
-      />
-    </a>
-
-  <audio id="player" preload="none" style="display: none">
-    <source src="/mp3/{{ $myVar4 }}.mp3" type="audio/mpeg" />
-  </audio>
-
-  <script>
-    let playing = false;
-    function togglePlayOrPause() {
-      if (playing) {
-        document.getElementById('player').pause();
-        document.getElementById('playbutton').classList.remove("pause");
-      } else {
-        document.getElementById('player').play();
-        document.getElementById('playbutton').classList.add("pause");
-      }
-      playing = !playing;
+<script>
+  let playing = false;
+  let firstTime = true;
+  function togglePlayOrPause() {
+    if (firstTime) {
+      document.getElementById('player-container').classList.add("show-player");
+      firstTime = false;
     }
-  </script>
+    if (playing) {
+      document.getElementById('player').pause();
+    } else {
+      document.getElementById('player').play();
+    }
+    playing = !playing;
+  }
+</script>
+
+{{ with .Page }}
+  {{ $myVar := print .Params.title "_Utilitarianism_net" }}
+  {{ $myVar2 := replaceRE "( |,|_|-|—|:|'|\\.|  )" "_" $myVar }}
+  {{ $myVar3 := replace $myVar2 "__" "_" }}
+  {{ $myVar4 := replace $myVar3 "__" "_" }}
+
+<div id="player-container" class="audio-player">
+  <audio id="player" controls preload="none">
+    <source src="/mp3/temp.mp3" type="audio/mpeg" />
+  </audio>
+</div>
+
+<div class="pdf-download">
 
   <div onclick="togglePlayOrPause()" class="mp3" title="Play audio recording of content">
-    <button id="playbutton"></button>
+    <img
+      src="/img/audio.svg"
+      title="Play audio recording of content"
+      alt="Play audio"
+    />
   </div>
 
-  <a href="/mp3/{{ $myVar4 }}.mp3">
+  <a href="/pdf/{{ $myVar4 }}.pdf">
     <img
-      src="/img/mp3.svg"
+      src="/img/pdf.svg"
       class="pdf-icon"
-      title="Download as MP3"
-      alt="MP3 download"
+      title="Download as PDF"
+      alt="PDF download"
     />
   </a>
 
-  {{ end }}
-
 </div>
+
+{{ end }}

--- a/layouts/partials/PDF.html
+++ b/layouts/partials/PDF.html
@@ -1,17 +1,7 @@
 <script>
-  let playing = false;
-  let firstTime = true;
   function togglePlayOrPause() {
-    if (firstTime) {
-      document.getElementById('player-container').classList.add("show-player");
-      firstTime = false;
-    }
-    if (playing) {
-      document.getElementById('player').pause();
-    } else {
-      document.getElementById('player').play();
-    }
-    playing = !playing;
+    document.getElementById('player-container').classList.add("show-player");
+    document.getElementById('audio-icon').outerHTML = "";
   }
 </script>
 
@@ -22,20 +12,24 @@
   {{ $myVar4 := replace $myVar3 "__" "_" }}
 
 <div id="player-container" class="audio-player">
-  <audio id="player" controls preload="none">
-    <source src="/mp3/temp.mp3" type="audio/mpeg" />
-  </audio>
+
+  <type-3-player
+    mp3-url="https://dl.type3.audio/episode/83895ceb-af1f-4099-b517-31bdcbe19017.mp3"
+    subscribe-url--apple="https://podcasts.apple.com/us/podcast/introduction-to-utilitarianism/id1696998316"
+    subscribe-url--spotify="https://open.spotify.com/show/7efBJVNSuPMcj6LaMSfuDf"
+    subscribe-url--podcast-addict="https://podcastaddict.com/podcast/introduction-to-utilitarianism/4535260"
+    subscribe-url--rss="https://feeds.type3.audio/utilitarianism-net.rss"
+    primary-color="#0b3b5b"
+    accent-color="#0b3b5b"
+    t3a-logo="false"
+    background-color="#f5f5f5"
+    waveform-color="#cad5dc"
+  >
+  </type-3-player>
+
 </div>
 
 <div class="pdf-download">
-
-  <div onclick="togglePlayOrPause()" class="mp3" title="Play audio recording of content">
-    <img
-      src="/img/audio.svg"
-      title="Play audio recording of content"
-      alt="Play audio"
-    />
-  </div>
 
   <a href="/pdf/{{ $myVar4 }}.pdf">
     <img
@@ -45,6 +39,14 @@
       alt="PDF download"
     />
   </a>
+
+  <div id="audio-icon" onclick="togglePlayOrPause()" class="mp3" title="Play audio recording of content">
+    <img
+      src="/img/audio.svg"
+      title="Play audio recording of content"
+      alt="Play audio"
+    />
+  </div>
 
 </div>
 

--- a/layouts/partials/PDF.html
+++ b/layouts/partials/PDF.html
@@ -14,7 +14,6 @@
 <div id="player-container" class="audio-player">
 
   <type-3-player
-    mp3-url="https://dl.type3.audio/episode/83895ceb-af1f-4099-b517-31bdcbe19017.mp3"
     subscribe-url--apple="https://podcasts.apple.com/us/podcast/introduction-to-utilitarianism/id1696998316"
     subscribe-url--spotify="https://open.spotify.com/show/7efBJVNSuPMcj6LaMSfuDf"
     subscribe-url--podcast-addict="https://podcastaddict.com/podcast/introduction-to-utilitarianism/4535260"

--- a/layouts/partials/PDF.html
+++ b/layouts/partials/PDF.html
@@ -14,5 +14,38 @@
         alt="PDF download"
       />
     </a>
+
+  <audio id="player" preload="none" style="display: none">
+    <source src="/mp3/{{ $myVar4 }}.mp3" type="audio/mpeg" />
+  </audio>
+
+  <script>
+    let playing = false;
+    function togglePlayOrPause() {
+      if (playing) {
+        document.getElementById('player').pause();
+        document.getElementById('playbutton').classList.remove("pause");
+      } else {
+        document.getElementById('player').play();
+        document.getElementById('playbutton').classList.add("pause");
+      }
+      playing = !playing;
+    }
+  </script>
+
+  <div onclick="togglePlayOrPause()" class="mp3" title="Play audio recording of content">
+    <button id="playbutton"></button>
+  </div>
+
+  <a href="/mp3/{{ $myVar4 }}.mp3">
+    <img
+      src="/img/mp3.svg"
+      class="pdf-icon"
+      title="Download as MP3"
+      alt="MP3 download"
+    />
+  </a>
+
   {{ end }}
+
 </div>

--- a/layouts/partials/footnotes-script.html
+++ b/layouts/partials/footnotes-script.html
@@ -16,3 +16,9 @@
                     </div>`,
   });
 </script>
+
+<script
+  type="module"
+  crossorigin
+  src="https://embed.type3.audio/player.js"
+></script>

--- a/static/img/audio.svg
+++ b/static/img/audio.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="#0b3959" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z"/>
+</svg>

--- a/static/img/mp3.svg
+++ b/static/img/mp3.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512" xml:space="preserve">
   <path style="fill:#e2e5e7" d="M128 0c-17.6 0-32 14.4-32 32v448c0 17.6 14.4 32 32 32h320c17.6 0 32-14.4 32-32V128L352 0H128z"/>
   <path style="fill:#b0b7bd" d="M384 128h96L352 0v96c0 17.6 14.4 32 32 32z"/>
-  <path style="fill:#f15642" d="M416 416c0 8.8-7.2 16-16 16H48c-8.8 0-16-7.2-16-16V256c0-8.8 7.2-16 16-16h352c8.8 0 16 7.2 16 16v160z"/>
-  <text x="90" y="385" fill="white" font-size="130px" font-weight="bold" font-family="arial">PDF</text>
+  <path style="fill:#0b3959" d="M416 416c0 8.8-7.2 16-16 16H48c-8.8 0-16-7.2-16-16V256c0-8.8 7.2-16 16-16h352c8.8 0 16 7.2 16 16v160z"/>
+  <text x="90" y="385" fill="white" font-size="130px" font-weight="bold" font-family="arial">MP3</text>
 </svg>


### PR DESCRIPTION
Wherever there is a "download PDF" we'll have an MP3 icon to download and a _play_ icon to play / pause the audio.

While we _could_ expose audio controls (see [example](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)), the way it shows up looks different depending on the browser, and it may be hard to scrub left-right when the progress bar is small, and I feel like making the controls as large as default is too intrusive into the simple design we have our website.

Thoughts welcome 🤝 

<img width="184" alt="image" src="https://github.com/whyboris/utilitarianism.net/assets/17264277/c386eacd-c27b-4a16-9977-03aed6f204ea">

ps - once we agree on design and figure out what pages we have audio for, we can make the MP3 part appear conditionally (rather than everywhere there is a PDF present).