### PR TITLE
Pagefind 1.0.4

### DIFF
--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -22,6 +22,7 @@
   .pagefind-ui__search-input {
     width: 130px;
     height: 40px;
+    outline: 0;
 
     left: calc(50vw + 286px);
     padding: 3px 0 0 42px !important;

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -134,7 +134,7 @@ After adding a document it will likely need some manual fixes:
   - If `npm install` errors out on _Windows_, consider using the `PowerShell` terminal instead
   - It is build with `just search` and is part of the `just build` command, no manual steps needed
   - During the build, to add image previews to the side of search results, `search = true` is toggled in `config.toml`
-  - Durning the build, `hugo` runs in parallel with `pagefind --source public` which creates the `_pagefind` folder inside `/public`
+  - Durning the build, `hugo` runs in parallel with `pagefind --site public` which creates the `pagefind` folder inside `/public`
 - If you run _hugo_ and see the warning _"port 1313 already in use, attempting to use an available port"_ try `npm run kill-hugo` which is equivalent to [`npx kill-port 1313`](https://github.com/tiaanduplessis/kill-port)
 
 When you run the `npm run build` script, under the hood we'll use `just` to execute these in order:

--- a/justfile
+++ b/justfile
@@ -1,9 +1,9 @@
 run:
   hugo serve
 
-build: clean search pdf production zip serve
+build: clean search pdf production move delete zip serve
 
-nopdf: clean search production zip serve
+nopdf: clean search production move delete zip serve
 
 @clean:
   rm -rf public
@@ -14,10 +14,27 @@ nopdf: clean search production zip serve
 @search:
   node build.js search
   hugo
+  just move
   npm run search
   node build.js reset
   echo ""
-  echo "   🚀  Search index generated"
+  echo "   🚀  search index generated"
+  echo ""
+
+@move:
+  cp -R public/en/* public
+  rm -rf public/en
+  echo ""
+  echo "   🚀  moved public/en to /public"
+  echo ""
+
+@delete:
+  rm -rf public/de
+  rm -rf public/en
+  rm -rf public/es
+  rm -rf public/docx
+  echo ""
+  echo "   🚀  removed extra folders from /public"
   echo ""
 
 @pdf:

--- a/layouts/partials/head-extra.html
+++ b/layouts/partials/head-extra.html
@@ -6,5 +6,5 @@
   href="/littlefoot.css"
 />
 
-<link href="/_pagefind/pagefind-ui.css" rel="stylesheet" />
-<script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
+<script src="/pagefind/pagefind-ui.js" type="text/javascript"></script>

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 {{ if .Site.Params.production }}
 Allow: /
-Disallow: /_pagefind/*
+Disallow: /pagefind/*
 Sitemap: {{.Site.BaseURL}}/sitemap.xml
 {{ else }}
 Disallow: /

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "hugo serve",
     "build": "just build",
-    "search": "pagefind --source public",
+    "search": "pagefind --site public",
     "pdf":      "cd pdf && website2pdf --marginTop 50px --marginBottom 50px --marginLeft 40px --marginRight 40px --display-header-footer --safe-title --output-dir ./temp && npm run move-pdf",
     "book-pdf": "cd pdf && website2pdf --marginTop 40px --marginBottom 40px --marginLeft 30px --marginRight 30px --display-header-footer false --safe-title --format a5 --output-dir ./temp && npm run move-pdf && npm run merge-pdf",
     "merge-pdf": "cd pdf && node build-book.js",
@@ -25,7 +25,7 @@
     "bestzip": "2.2.1",
     "fdir": "6.0.1",
     "kill-port": "2.0.1",
-    "pagefind": "0.12.0",
+    "pagefind": "1.0.4",
     "pdf-merger-js": "4.2.1",
     "prettier": "2.8.4",
     "prettier-plugin-go-template": "0.0.13",


### PR DESCRIPTION
_Pagefind_ has been updated to version `1.0.4` 

See release notes: [Pagefind 1.0.0](https://github.com/CloudCannon/pagefind/releases/tag/v1.0.0)

The `build` script has been updated to work with the `public/en` build folder 🚀 